### PR TITLE
Better scheduling and job logs

### DIFF
--- a/core/definition.json
+++ b/core/definition.json
@@ -20,7 +20,7 @@
       "keyPair": "#{myEC2KeyPair}",
       "masterInstanceType": "#{myMasterInstanceType}",
       "releaseLabel": "#{myEMRReleaseLabel}",
-      "terminateAfter": "120 Minutes",
+      "terminateAfter": "180 Minutes",
       "applications": "spark",
       "configuration": {"ref": "spark-env" }
     },

--- a/core/definition.json
+++ b/core/definition.json
@@ -20,7 +20,7 @@
       "keyPair": "#{myEC2KeyPair}",
       "masterInstanceType": "#{myMasterInstanceType}",
       "releaseLabel": "#{myEMRReleaseLabel}",
-      "terminateAfter": "180 Minutes",
+      "terminateAfter": "300 Minutes",
       "applications": "spark",
       "configuration": {"ref": "spark-env" }
     },

--- a/core/definition.json
+++ b/core/definition.json
@@ -20,7 +20,7 @@
       "keyPair": "#{myEC2KeyPair}",
       "masterInstanceType": "#{myMasterInstanceType}",
       "releaseLabel": "#{myEMRReleaseLabel}",
-      "terminateAfter": "50 Minutes",
+      "terminateAfter": "120 Minutes",
       "applications": "spark",
       "configuration": {"ref": "spark-env" }
     },

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -44,7 +44,6 @@ class DeployPySparkScriptOnAws(object):
         self.app_file = yml.py_job  # TODO: remove all refs to app_file to be consistent.
         self.yml = yml
         self.aws_setup = aws_setup
-        # self.app_name = self.yml.job_name.replace('.','_dot_').split('/')[-1]  # TODO: integrate in yml obj and use it here.
         self.ec2_key_name  = config.get(aws_setup, 'ec2_key_name')
         self.s3_region     = config.get(aws_setup, 's3_region')
         self.user          = config.get(aws_setup, 'user')
@@ -529,7 +528,9 @@ class DeployPySparkScriptOnAws(object):
 
 
 def deploy_all_scheduled():
-
+    ### Experimental ! Has lead to errors like: /usr/bin/python3: can't open file '/home/hadoop/app/jobs/frontroom/hotel_staff_usage_job.py': [Errno 2] No such file or directory
+    ### pb I don't get when deploying normally, from job files.
+    ### TODO: also need to remove "dependency" run for the ones with no dependencies.
     def get_yml(args):
         meta_file = args.get('job_param_file', 'repo')
         if meta_file is 'repo':
@@ -553,7 +554,7 @@ def deploy_all_scheduled():
                    'aws_config_file':eu.AWS_CONFIG_FILE, # TODO: make set-able
                    'aws_setup':'dev'}
     app_args = {'mode':'EMR_Scheduled',
-                'job_param_file': 'conf/jobs_metadata.yml', # TODO: make set-able
+                'job_param_file': 'conf/jobs_metadata.yml', # TODO: make set-able. Set to external repo for testing.
                 'boxed_dependencies': True,
                 'dependencies': True,
                 'storage': 'local',
@@ -612,4 +613,4 @@ if __name__ == "__main__":
     print('#--- pipelines: ', pipelines)
 
     # (Re)deploy schedule jobs
-    deploy_all_scheduled()
+    #deploy_all_scheduled() # needs more testing.

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -388,7 +388,6 @@ class DeployPySparkScriptOnAws(object):
         pipe_id = self.create_data_pipeline(client)
         parameterValues = self.define_data_pipeline(client, pipe_id)
         self.activate_data_pipeline(client, pipe_id, parameterValues)
-        # self.deactivate_older_pipeline(client, self.job_name)
 
     def create_data_pipeline(self, client):
         unique_id = uuid.uuid1()
@@ -440,14 +439,11 @@ class DeployPySparkScriptOnAws(object):
 
     def deactivate_similar_pipelines(self, client, pipeline_id):
         pipelines = self.list_data_pipeline(client)
-        # print('#--- pipelines:', pipelines)
         for item in pipelines:
-            # item.update({'job_name': self.get_job_name(item['name'])})
             job_name = self.get_job_name(item['name'])
             if job_name == self.yml.job_name:
                 response = client.deactivate_pipeline(pipelineId=item['id'], cancelActive=True)
-                logger.info('Deactivated pipeline ' + item)
-                # import ipdb; ipdb.set_trace()
+                logger.info('Deactivated pipeline {}, {}, {}'.format(job_name, item['name'], item['id']))
 
     def update_params(self, parameterValues):
         # TODO: check if easier/simpler to change values at the source json instead of a processed one.

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -552,7 +552,6 @@ def deploy_all_scheduled():
                    'aws_config_file':eu.AWS_CONFIG_FILE, # TODO: make set-able
                    'aws_setup':'dev'}
     app_args = {'mode':'EMR_Scheduled',
-                'job_param_file': '/Users/aprevot/myTHNDocs/code_thn/datapipelines/conf/jobs_metadata.yml', # TODO: make set-able
                 'job_param_file': 'conf/jobs_metadata.yml', # TODO: make set-able
                 'boxed_dependencies': True,
                 'dependencies': True,

--- a/core/scripts/setup_master.sh
+++ b/core/scripts/setup_master.sh
@@ -19,6 +19,7 @@ sudo pip-3.6 install simple-salesforce==1.0.0
 sudo pip-3.6 install pymysql==0.9.3
 sudo pip-3.6 install psycopg2-binary==2.8.5  # necesary for sqlalchemy-redshift, psycopg2==2.8.5 fails installing.
 sudo pip-3.6 install sqlalchemy-redshift==0.7.7
+sudo pip-3.6 install stripe==2.50.0
 
 # Copy compressed script tar file from S3 to EMR master, after deploy.py moved it from laptop to S3.
 echo "Copy S3 to EMR master"

--- a/libs/analysis_toolkit/query_helper.py
+++ b/libs/analysis_toolkit/query_helper.py
@@ -145,6 +145,7 @@ def write_file(fname, content):
     fh.close()
 
 def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_deltas=True):
+    """Note: Doesn't support both dfs having same column names (or at least the ones that need to be compared.)"""
     print('Length df1', len(df1), df1[pks1].nunique())
     print('Length df2', len(df2), df2[pks2].nunique())
 
@@ -167,7 +168,7 @@ def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_del
         elif float(row[item1]) == 0 or float(row[item2]) == 0:
             return 100
         else:
-            return np.abs(np.divide((row[item1]-row[item2]), float(row[item1])))
+            return np.abs(np.divide((row[item1]-row[item2]), float(row[item1])))*100
 
     # Check deltas
     threshold = 0.01
@@ -175,6 +176,7 @@ def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_del
     for ii in range(len(compare1)):
         item1 = compare1[ii]
         item2 = compare2[ii]
+        assert item1!=item2
         df_joined['_delta_'+item1] = df_joined.apply(lambda row: (row[item1] if not np.isnan(row[item1]) else 0.0)-(row[item2] if not np.isnan(row[item2]) else 0.0), axis=1) # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
         df_joined['_delta_'+item1+'_%'] = df_joined.apply(check_delta, axis=1)
         df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas']==True and row['_delta_'+item1+'_%']<threshold, axis=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ botocore==1.8.7
 networkx==2.4
 pandas==0.25.3
 pytest==5.3.0
-sqlalchemy==1.1.13
+sqlalchemy==1.3.15
 scikit-learn==0.20.0
 statsmodels==0.9.0
 kafka-python==1.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ statsmodels==0.9.0
 kafka-python==1.4.7
 jsonschema==3.0.2
 flake8==3.7.9
+stripe==2.50.0


### PR DESCRIPTION
Easier scheduling with AWS Data Pipeline:
 * now put previously scheduled job as inactive before pushing the new version. Removes need for manual ops.
 * implied changing pipeline naming scheme so it can be traced to job programmatically.
 * implied adding ability to list data pipelines from API and refactoring calls to AWS Data Pipeline.

Other
 * Changed location of job logs to make it cleaner, closer to jobs data.
 * created new deploy_all_scheduled(). Doesn't work reliably. Needs more testing..
 * added stripe libs
 * update to compare_dfs()