### PR TITLE
Sending jobs to EMR from docker + koalas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/build:$PYTHONPATH
 
 ENV PYSPARK_AWS_ETL_JOBS_HOME /mnt/external_pipelines/
 # or replace "/mnt/external_pipelines/" by the name of your external repo to make it match.
+# TODO: fix external shared folders that can't be access from mac with current version of docker, although it works from ubuntu.
 
 # Expose ports for monitoring.
 # SparkContext web UI on 4040 -- only available for the duration of the application.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM jupyter/pyspark-notebook
 # USER root
 
 # Pip installs. Using local copy to tmp dir to allow checkpointing this step (no re-installs as long as requirements.txt doesn't change)
+RUN conda remove PyYAML --yes --offline
+# command above only necessary when using "jupyter/pyspark-notebook" image base, which uses conda as package manager and pip cannot uninstall version.
 COPY requirements.txt /tmp/requirements.txt
 WORKDIR /tmp/
 RUN pip3 install -r requirements.txt
@@ -18,8 +20,9 @@ ENV PYTHONPATH $PYSPARK_AWS_ETL_HOME:$PYTHONPATH
 ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/build:$PYTHONPATH
 
 ENV PYSPARK_AWS_ETL_JOBS_HOME /mnt/external_pipelines/
+ENV PYTHONPATH $PYSPARK_AWS_ETL_JOBS_HOME:$PYTHONPATH
 # or replace "/mnt/external_pipelines/" by the name of your external repo to make it match.
-# TODO: fix external shared folders that can't be access from mac with current version of docker, although it works from ubuntu.
+# TODO: fix external shared folders that can't be access from mac with current version of docker, but works from ubuntu.
 
 # Expose ports for monitoring.
 # SparkContext web UI on 4040 -- only available for the duration of the application.

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -61,6 +61,18 @@ examples/ex4_dependency4_job.py:
   output: {'path':'s3://sandbox-spark/wiki_example/output_ex4_dep4/{now}/', 'type':'csv'}
   dependencies: [examples/ex4_dependency3_job.sql]
 
+examples/ex7_frameworked_job.py:  # shows job with no output (still requiring table as output but no dumped to disk)
+  inputs:
+    some_events: {'path':"s3://sandbox-spark/wiki_example/inputs/{latest}/events_log.csv.gz", 'type':'csv'}
+    other_events: {'path':"s3://sandbox-spark//wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
+  output: {'path':'n/a', 'type':'None'}
+
+examples/ex8_koalas_job.py:
+  inputs:
+    some_events: {'path':"s3://sandbox-spark/wiki_example/inputs/{latest}/events_log.csv.gz", 'type':'csv'}
+    other_events: {'path':"s3://sandbox-spark/wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
+  output: {'path':'s3://sandbox-spark/wiki_example/output_ex8_koalas/{now}/', 'type':'csv'}
+
 
 examples/wordcount_frameworked_job.py:
   inputs:

--- a/conf/jobs_metadata_local.yml
+++ b/conf/jobs_metadata_local.yml
@@ -83,6 +83,13 @@ examples/ex7_frameworked_job.py:  # shows job with no output (still requiring ta
     other_events: {'path':"data/wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
   output: {'path':'n/a', 'type':'None'}
 
+examples/ex8_koalas_job.py:
+  inputs:
+    some_events: {'path':"data/wiki_example/inputs/{latest}/events_log.csv.gz", 'type':'csv'}
+    other_events: {'path':"data/wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
+  output: {'path':'data/wiki_example/output_ex8_koalas/{now}/', 'type':'csv'}
+
+
 examples/wordcount_frameworked_job.py:  # shows raw pyspark rdd ops in framework, same as wordcount_raw_job
   inputs:
     lines: {'path':"data/wordcount_example/input/sample_text.txt", 'type':'txt'}

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -50,7 +50,7 @@ class DeployPySparkScriptOnAws(object):
         self.profile_name  = config.get(aws_setup, 'profile_name')
         self.ec2_subnet_id = config.get(aws_setup, 'ec2_subnet_id')
         self.extra_security_gp = config.get(aws_setup, 'extra_security_gp')
-        self.emr_core_instances = int(config.get(aws_setup, 'emr_core_instances'))
+        self.emr_core_instances = int(app_args.get('emr_core_instances', 1))  # TODO: make this update EMR_Scheduled mode too.
         self.app_args = app_args
         self.deploy_args = deploy_args
         self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  #'m5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -266,8 +266,9 @@ class ETL_Base(object):
     def get_max_timestamp(self, df):
         return df.agg({self.OUTPUT['inc_field']: "max"}).collect()[0][0]
 
-    def save(self, output, now_dt):
-        path = Path_Handler(self.OUTPUT['path']).expand_now(now_dt)
+    def save(self, output, now_dt, path=None):
+        if path is None:
+            path = Path_Handler(self.OUTPUT['path']).expand_now(now_dt)
         self.path = path
 
         if self.OUTPUT['type'] == 'None':

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -785,11 +785,6 @@ class Flow():
         name_import = py_job.replace('/','.').replace('.py','')
         import_cmd = "from {} import Job".format(name_import)
         namespace = {}
-        logger.info('### ------- import_cmd: {}'.format(import_cmd))
-        #import jobs
-        logger.info('### ------- sys.modules jobs*: {}'.format([item for item in sys.modules.keys() if item.startswith('jobs') or item.__contains__('external')]))
-        logger.info('### ------- sys.path jobs*: {}'.format([item for item in sys.path if item.__contains__('jobs') or item.__contains__('external')]))
-        #import ipdb; ipdb.set_trace()
         exec(import_cmd, namespace)
         return namespace['Job']
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -107,6 +107,7 @@ class ETL_Base(object):
         self.save(output, self.start_dt)
         end_time = time()
         elapsed = end_time - start_time
+        logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
         # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
         if self.redshift_copy_params:

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -185,6 +185,7 @@ class ETL_Base(object):
 
             # Load from disk
             path = self.INPUTS[item]['path']
+            logger.info("Input '{}' to be loaded from files '{}'.".format(item, path))
             path = Path_Handler(path).expand_later(self.args['storage'])
             app_args[item] = self.load_data(path, self.INPUTS[item]['type'])
             logger.info("Input '{}' loaded from files '{}'.".format(item, path))

--- a/core/scripts/setup_master.sh
+++ b/core/scripts/setup_master.sh
@@ -13,6 +13,7 @@ sudo pip-3.6 install scikit-learn==0.20.0  # TODO: remove when using req file
 sudo pip-3.6 install statsmodels==0.9.0  # TODO: remove when using req file
 sudo pip-3.6 install kafka-python==1.4.7
 sudo pip-3.6 install jsonschema==3.0.2
+sudo pip-3.6 install koalas==1.3.0
 # DB and API libs
 sudo pip-3.6 install soql==1.0.2  # Necessary for simple-salesforce
 sudo pip-3.6 install simple-salesforce==1.10.1

--- a/core/scripts/setup_master.sh
+++ b/core/scripts/setup_master.sh
@@ -15,7 +15,7 @@ sudo pip-3.6 install kafka-python==1.4.7
 sudo pip-3.6 install jsonschema==3.0.2
 # DB and API libs
 sudo pip-3.6 install soql==1.0.2  # Necessary for simple-salesforce
-sudo pip-3.6 install simple-salesforce==1.0.0
+sudo pip-3.6 install simple-salesforce==1.10.1
 sudo pip-3.6 install pymysql==0.9.3
 sudo pip-3.6 install psycopg2-binary==2.8.5  # necesary for sqlalchemy-redshift, psycopg2==2.8.5 fails installing.
 sudo pip-3.6 install sqlalchemy-redshift==0.7.7

--- a/core/scripts/setup_nodes.sh
+++ b/core/scripts/setup_nodes.sh
@@ -5,5 +5,6 @@
 # Installs below are specific to python version, which is specific to EMR version. TODO: make it independant. Will be fixed when using to emr-6.x since python3 will be default and it will support pip3.
 sudo pip-3.6 install boto3==1.9.57
 sudo pip-3.6 install networkx==2.4
-sudo pip-3.6 install pandas==1.0.4
+sudo pip-3.6 install numpy==1.18.5  # need to force this version instead of latest (1.19.2) to be compatible with koalas 1.3.0 (requiring <1.19)
+sudo pip-3.6 install pandas==1.0.0  # downgraded from 1.0.4 to be compatible with koalas. 0.25.1
 sudo pip-3.6 install sqlalchemy==1.3.15  # don't use 1.3.17 since not compatible with sqlalchemy-redshift (0.7.7). See if it is still a pb at https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/195

--- a/jobs/examples/ex7_frameworked_job.py
+++ b/jobs/examples/ex7_frameworked_job.py
@@ -17,7 +17,7 @@ class Job(ETL_Base):
 
 if __name__ == "__main__":
     args = {
-        'job_param_file':   'conf/jobs_metadata_local.yml',  # Just to be explicit. Not needed since this is default.
+        'job_param_file':   'conf/jobs_metadata.yml',  # Just to be explicit. Not needed since this is default.
         'connection_file':  'conf/connections.cfg',  # Just to be explicit. Not needed since this is default.
         'aws_config_file':  'conf/aws_config.cfg',  # Just to be explicit. Not needed since this is default.
         'aws_setup':        'dev',  # Just to be explicit. Not needed since this is default.

--- a/jobs/examples/ex7_frameworked_job.py
+++ b/jobs/examples/ex7_frameworked_job.py
@@ -1,18 +1,10 @@
-"""Same as ex1_full_sql_job.sql but allows access to spark for more complex ops (not used here but in ex2_frameworked_job.py)."""
+"""Created to show job with no output."""
 from core.etl_utils import ETL_Base, Commandliner
 
 
 class Job(ETL_Base):
-    def transform(self, some_events, other_events):
-        df = self.query("""
-            SELECT se.session_id, count(*) as count_events
-            FROM some_events se
-            JOIN other_events oe on se.session_id=oe.session_id
-            WHERE se.action='searchResultPage' and se.n_results>0
-            group by se.session_id
-            order by count(*) desc
-            """)
-        return df
+    def transform(self, some_events):
+        return some_events
 
 
 if __name__ == "__main__":

--- a/jobs/examples/ex8_koalas_job.py
+++ b/jobs/examples/ex8_koalas_job.py
@@ -1,0 +1,32 @@
+"""To show koalas API"""
+from core.etl_utils import ETL_Base, Commandliner
+import pandas as pd
+import numpy as np
+import databricks.koalas as ks
+
+class Job(ETL_Base):
+    def transform(self, some_events, other_events):
+        # Convert spark df to koalas df
+        se_kdf = some_events.to_koalas()
+        oe_kdf = other_events.to_koalas()
+
+        # processing
+        se_kdf = se_kdf[se_kdf['action']=='searchResultPage']
+        se_kdf = se_kdf[se_kdf['n_results']>0]
+        merged_kdf = ks.merge(se_kdf, oe_kdf, on='session_id', how='inner', suffixes=('_l','_r'))
+        grouped = merged_kdf.groupby(by=['session_id']).count()
+
+        # back to spark df
+        sdf = grouped.to_spark()
+        return sdf
+
+
+if __name__ == "__main__":
+    args = {
+        'job_param_file':   'conf/jobs_metadata.yml',  # Just to be explicit. Not needed since this is default.
+        'connection_file':  'conf/connections.cfg',  # Just to be explicit. Not needed since this is default.
+        'aws_config_file':  'conf/aws_config.cfg',  # Just to be explicit. Not needed since this is default.
+        'aws_setup':        'dev',  # Just to be explicit. Not needed since this is default.
+        'jobs_folder':      'jobs/',  # Just to be explicit. Not needed since this is default.
+        }
+    Commandliner(Job, **args)

--- a/jobs/examples/ex8_koalas_job.py
+++ b/jobs/examples/ex8_koalas_job.py
@@ -1,4 +1,4 @@
-"""To show koalas API"""
+"""To show koalas API. Same process as SQL code in ex2_frameworked_job.py"""
 from core.etl_utils import ETL_Base, Commandliner
 import pandas as pd
 import numpy as np

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # For docker env. TODO: use it for AWS setup too, would involve splitting it in 2 req files (master and slave sides).
 #pyyaml==5.1.2
+ipdb==0.13.4
 awscli==1.16.67
 # awscli necessary to deploy to AWS Data Pipeline
 boto3==1.9.57
@@ -7,7 +8,7 @@ boto3==1.9.57
 networkx==2.4
 numpy==1.18.5
 # numpy needs to be forced this version instead of latest (1.19.2) to be compatible with koalas 1.3.0 (requiring <1.19)
-pandas==1.0.4
+pandas==1.0.0
 pytest==5.3.0
 sqlalchemy==1.3.15
 scikit-learn==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # For docker env. TODO: use it for AWS setup too, would involve splitting it in 2 req files (master and slave sides).
 #pyyaml==5.1.2
-#awscli==1.16.67
+awscli==1.16.67
+# awscli necessary to deploy to AWS Data Pipeline
 boto3==1.9.57
 #botocore==1.8.7
 networkx==2.4
@@ -14,7 +15,7 @@ jsonschema==3.0.2
 flake8==3.7.9
 stripe==2.50.0
 soql==1.0.2
-simple-salesforce==1.0.0
+simple-salesforce==1.10.1
 pymysql==0.9.3
 psycopg2-binary==2.8.5
 sqlalchemy-redshift==0.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ awscli==1.16.67
 boto3==1.9.57
 #botocore==1.8.7
 networkx==2.4
+numpy==1.18.5
+# numpy needs to be forced this version instead of latest (1.19.2) to be compatible with koalas 1.3.0 (requiring <1.19)
 pandas==1.0.4
 pytest==5.3.0
 sqlalchemy==1.3.15
@@ -20,3 +22,4 @@ pymysql==0.9.3
 psycopg2-binary==2.8.5
 sqlalchemy-redshift==0.7.7
 stripe==2.50.0
+koalas==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For docker env. TODO: use it for AWS setup too, would involve splitting it in 2 req files (master and slave sides).
-#pyyaml==5.1.2
+#pyyaml==5.1.2  # will install 3.13 because of boto requirement lower.
 ipdb==0.13.4
 awscli==1.16.67
 # awscli necessary to deploy to AWS Data Pipeline


### PR DESCRIPTION
 * added awscli lib to allow sending jobs to AWS from docker.
 * added koalas lib and job to test it. Works fine, including in EMR + other lib updates to all work from docker. 
 * fixed running jobs with dependencies from external folders in docker. cc @JoanRamos 
 * update to allow changing number of EC2 instances in EMR for each jobs (doesn't carry to scheduled jobs yet).
 * saving to S3 more flexible so it can be used inside jobs (so 1 job -> multiple outputs)
