### PR TITLE
Enable dev domain usage on Salesforce

### DIFF
--- a/libs/python_db_connectors/query_salesforce.py
+++ b/libs/python_db_connectors/query_salesforce.py
@@ -15,7 +15,8 @@ def connect(creds_section, creds_or_file='conf/connections.cfg'):
     user = config.get(creds_section, 'user')
     pwd = config.get(creds_section, 'password')
     token = config.get(creds_section, 'token')
-    return Salesforce(username=user, password=pwd, security_token=token)
+    domain = None if config.get(creds_section, 'domain') == 'production' else config.get(creds_section, 'domain')
+    return Salesforce(username=user, password=pwd, security_token=token, domain=domain)
 
 def query(query_str, **connect_args):
     sf = connect(**connect_args)


### PR DESCRIPTION
Define the salesforce domain on the connections file to easily work between Production and Dev environments