### PR TITLE
Reusable jobs + refactor Job arguments

### DIFF
--- a/conf/jobs_metadata_local.yml
+++ b/conf/jobs_metadata_local.yml
@@ -11,6 +11,13 @@ examples/ex1_frameworked_job.py:  # shows frameworked pyspark ops, same as ex1_f
     other_events: {'path':"data/wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
   output: {'path':'data/wiki_example/output_ex1_frameworked/{now}/', 'type':'csv'}
 
+job_using_generic_template:
+  py_job: 'jobs/examples/ex1_frameworked_job.py'
+  inputs:
+    some_events: {'path':"data/wiki_example/inputs/{latest}/events_log.csv.gz", 'type':'csv'}
+    other_events: {'path':"data/wiki_example/inputs/{latest}/other_events_log.csv.gz", 'type':'csv'}
+  output: {'path':'data/wiki_example/output_ex1_frameworked_p2/{now}/', 'type':'csv'}
+
 # ex1_raw_job:  # shows raw pyspark ops, no helper functions to deal with boilerplate. Job exists but doesn't rely on jobs_metadata entries
 
 examples/ex2_frameworked_job.py:  # more complex version of ex1_frameworked_job

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -547,7 +547,7 @@ def deploy_all_scheduled():
         meta_file = args.get('job_param_file', 'repo')
         if meta_file is 'repo':
             meta_file = eu.CLUSTER_APP_FOLDER+eu.JOBS_METADATA_FILE if args['storage']=='s3' else eu.JOBS_METADATA_LOCAL_FILE
-        yml = eu.Job_Yml_Parser.load_meta(meta_file)
+        yml = eu.Job_Args_Parser.load_meta(meta_file)
         logger.info('Loaded job param file: ' + meta_file)
         return yml
 

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -379,13 +379,14 @@ class DeployPySparkScriptOnAws(object):
             "--mode=localEMR",
             "--storage=s3",
             '--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER+eu.JOBS_METADATA_FILE),
-            "--dependencies" if app_args.get('dependencies') else "",
-            "--boxed_dependencies" if app_args.get('boxed_dependencies') else "",
             "--rerun_criteria={}".format(app_args.get('rerun_criteria')),
-            "--sql_file={}".format(eu.CLUSTER_APP_FOLDER+app_args['sql_file']) if app_args.get('sql_file') else "",
             ]
-        cmd_runner_args = [item for item in cmd_runner_args if item]
-        return cmd_runner_args
+        dep = ["--dependencies"] if app_args.get('dependencies') else []
+        box = ["--boxed_dependencies"] if app_args.get('boxed_dependencies') else []
+        sql = ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER+app_args['sql_file'])] if app_args.get('sql_file') else []
+        nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
+
+        return cmd_runner_args + dep + box + sql + nam
 
     def run_aws_data_pipeline(self):
         self.s3_ops(self.session)

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -23,6 +23,7 @@ from configparser import ConfigParser
 from shutil import copyfile
 import core.etl_utils as eu
 import core.logger as log
+logger = log.setup_logging('Deploy')
 
 
 class DeployPySparkScriptOnAws(object):
@@ -599,20 +600,12 @@ def terminate(error_message=None):
     exit()
 
 
-logger = log.setup_logging('Deploy')
-
-
 if __name__ == "__main__":
     # Deploying 1 job manually.
     # Use as standalone to push random python script to cluster.
     # TODO: fails to create a new cluster but works to add a step to an existing cluster.
     print('command line: ', ' '.join(sys.argv))
     job_name = sys.argv[1] if len(sys.argv) > 1 else 'examples/ex1_raw_job_cluster.py'  # TODO: move to 'jobs/examples/ex1_raw_job_cluster.py'
-    # class bag(object):
-    #     pass
-    # jargs = bag()
-    # jargs.job_name = job_name
-    # jargs.py_job = job_name # will add /home/hadoop/app/  # TODO: try later as better from cmdline.
     deploy_args = {'leave_on': True, 'aws_config_file':eu.AWS_CONFIG_FILE, 'aws_setup':'dev'}
     app_args = {'job_name':job_name, 'py_job':py_job, 'mode':'EMR'}
     DeployPySparkScriptOnAws(deploy_args, app_args).run()

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -32,7 +32,7 @@ class DeployPySparkScriptOnAws(object):
     SCRIPTS = 'core/scripts/' # TODO: move to etl_utils.py
     TMP = 'tmp/files_to_ship/'
 
-    def __init__(self, yml, deploy_args, app_args):
+    def __init__(self, jargs, deploy_args, app_args):  # TODO remove "app_args" and use the data from jargs instead.
 
         logger.info("etl deploy_args: {}".format(deploy_args))
         logger.info("etl app_args: {}".format(app_args))
@@ -41,8 +41,8 @@ class DeployPySparkScriptOnAws(object):
         assert os.path.isfile(deploy_args['aws_config_file'])
         config.read(deploy_args['aws_config_file'])
 
-        self.app_file = yml.py_job  # TODO: remove all refs to app_file to be consistent.
-        self.yml = yml
+        self.app_file = jargs.py_job  # TODO: remove all refs to app_file to be consistent.
+        self.jargs = jargs
         self.aws_setup = aws_setup
         self.ec2_key_name  = config.get(aws_setup, 'ec2_key_name')
         self.s3_region     = config.get(aws_setup, 's3_region')
@@ -58,7 +58,7 @@ class DeployPySparkScriptOnAws(object):
         # Paths
         self.s3_bucket_logs = config.get(aws_setup, 's3_bucket_logs')
         self.metadata_folder = 'pipelines_metadata'
-        self.job_name = self.generate_pipeline_name(self.yml.job_name, self.user)  #TODO: rename job_name to pipeline_name format: some_job.some_user.20181204.153429
+        self.job_name = self.generate_pipeline_name(self.jargs.job_name, self.user)  #TODO: rename job_name to pipeline_name format: some_job.some_user.20181204.153429
         self.job_log_path = '{}/jobs_code/{}'.format(self.metadata_folder, self.job_name)  # format: yaetos/logs/some_job.some_user.20181204.153429
         self.job_log_path_with_bucket = '{}/{}'.format(self.s3_bucket_logs, self.job_log_path)   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429
         self.package_path  = self.job_log_path+'/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
@@ -451,7 +451,7 @@ class DeployPySparkScriptOnAws(object):
         pipelines = self.list_data_pipeline(client)
         for item in pipelines:
             job_name = self.get_job_name(item['name'])
-            if job_name == self.yml.job_name:
+            if job_name == self.jargs.job_name:
                 response = client.deactivate_pipeline(pipelineId=item['id'], cancelActive=True)
                 logger.info('Deactivated pipeline {}, {}, {}'.format(job_name, item['name'], item['id']))
 
@@ -459,14 +459,14 @@ class DeployPySparkScriptOnAws(object):
         # TODO: check if easier/simpler to change values at the source json instead of a processed one.
         # Change key pair
         myScheduleType = {'EMR_Scheduled': 'cron', 'EMR_DataPipeTest': 'ONDEMAND'}[self.app_args.get('mode')]
-        myPeriod = self.yml.frequency or '1 Day'
-        if self.yml.start_date and isinstance(self.yml.start_date, datetime):
-            myStartDateTime = self.yml.start_date.strftime('%Y-%m-%dT%H:%M:%S')
-        elif self.yml.start_date and isinstance(self.yml.start_date, str):
-            myStartDateTime = self.yml.start_date.format(today=datetime.today().strftime('%Y-%m-%d'))
+        myPeriod = self.jargs.frequency or '1 Day'
+        if self.jargs.start_date and isinstance(self.jargs.start_date, datetime):
+            myStartDateTime = self.jargs.start_date.strftime('%Y-%m-%dT%H:%M:%S')
+        elif self.jargs.start_date and isinstance(self.jargs.start_date, str):
+            myStartDateTime = self.jargs.start_date.format(today=datetime.today().strftime('%Y-%m-%d'))
         else :
             myStartDateTime = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
-        # TODO: self.yml.start_date is taken from jobs_metadata_local.yml, instead of jobs_metadata.yml. Fix it
+        # TODO: self.jargs.start_date is taken from jobs_metadata_local.yml, instead of jobs_metadata.yml. Fix it
         bootstrap = 's3://{}/setup_nodes.sh'.format(self.package_path_with_bucket)
 
         for ii, item in enumerate(parameterValues):
@@ -575,16 +575,16 @@ def deploy_all_scheduled():
     yml = get_yml(app_args)
     pipelines = yml.keys()
     for pipeline in pipelines:
-        job_yml = eu.Job_Yml_Parser(app_args)
-        job_yml.set_job_params(job_name=pipeline)
-        if not job_yml.frequency:
+        jargs = eu.Job_Yml_Parser(app_args)
+        jargs.set_job_params(job_name=pipeline) # broken TODO: fix.
+        if not jargs.frequency:
             continue
 
         run = validate_job(pipeline)
         if not run:
             continue
 
-        DeployPySparkScriptOnAws(job_yml, deploy_args, app_args).run()
+        DeployPySparkScriptOnAws(jargs, deploy_args, app_args).run()
 
 
 def terminate(error_message=None):
@@ -609,15 +609,15 @@ if __name__ == "__main__":
     job_name = sys.argv[1] if len(sys.argv) > 1 else 'examples/ex1_raw_job_cluster.py'  # TODO: move to 'jobs/examples/ex1_raw_job_cluster.py'
     class bag(object):
         pass
-    job_yml = bag()
-    job_yml.job_name = job_name
-    job_yml.py_job = job_name # will add /home/hadoop/app/  # TODO: try later as better from cmdline.
+    jargs = bag()
+    jargs.job_name = job_name
+    jargs.py_job = job_name # will add /home/hadoop/app/  # TODO: try later as better from cmdline.
     deploy_args = {'leave_on': True, 'aws_config_file':eu.AWS_CONFIG_FILE, 'aws_setup':'dev'}
     app_args = {'mode':'EMR'}
-    DeployPySparkScriptOnAws(job_yml, deploy_args, app_args).run()
+    DeployPySparkScriptOnAws(jargs, deploy_args, app_args).run()
 
     # Show list of all jobs running.
-    deployer = DeployPySparkScriptOnAws(job_yml, deploy_args, app_args)
+    deployer = DeployPySparkScriptOnAws(jargs, deploy_args, app_args)
     client = deployer.session.client('datapipeline')
     pipelines = deployer.list_data_pipeline(client)
     print('#--- pipelines: ', pipelines)
@@ -630,6 +630,6 @@ if __name__ == "__main__":
     app_args = {'job_param_file':'conf/jobs_metadata_local.yml',
                 'jobs_folder':'jobs',
                 }
-    deployer = DeployPySparkScriptOnAws(job_yml, deploy_args, app_args)  # TODO: should remove need for some of these inputs as they are not required by tar_python_scripts()
+    deployer = DeployPySparkScriptOnAws(jargs, deploy_args, app_args)  # TODO: should remove need for some of these inputs as they are not required by tar_python_scripts()
     pipelines = deployer.tar_python_scripts()
     print('#--- Finished packaging ---')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -152,7 +152,6 @@ class ETL_Base(object):
         # TODO: redo without without the mapping.
         job_file = self.set_job_file() # file where code is, could be .py or .sql. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
         job_yml_parser = Job_Args_Parser(cmd_args=self.args, job_file=job_file, get_all=True, loaded_inputs=loaded_inputs)  # has to be removed since already done in Commandliner()
-        # job_yml_parser.set_job_params(loaded_inputs, job_file=self.job_file)
 
         self.job_name = job_yml_parser.job_name  # name as written in jobs_metadata file, ex "examples/ex1_frameworked_job.py" or "examples/ex1_full_sql_job.sql"
         self.py_job = job_yml_parser.py_job  # name of python file supporting execution. Different from job_file for sql jobs or other generic python files.
@@ -160,7 +159,7 @@ class ETL_Base(object):
         if self.args.get('job_param_file'):
             self.job_yml = job_yml_parser.yml_args
         self.INPUTS = job_yml_parser.INPUTS
-        print('##----- self.INPUTS:',self.INPUTS)
+        # print('##----- self.INPUTS:',self.INPUTS)
         self.OUTPUT = job_yml_parser.OUTPUT
         self.frequency = job_yml_parser.frequency
         self.redshift_copy_params = job_yml_parser.redshift_copy_params
@@ -373,13 +372,13 @@ class Job_Args_Parser():
     # TODO: rewrite all. without relying on class attributes, without requiring args, and avoid rerunning it from within the job if ran from Flow()
     def __init__(self, cmd_args={}, job_file=None, get_all=True, loaded_inputs={}):
         # print('##----- loading Job_Args_Parser:')
-        job_name, py_job, yml_args = self.set_job_name(cmd_args, job_file)
+        job_name, py_job, yml_args = self.set_job_main_params(cmd_args, job_file)
         if get_all:
-            self.set_job_params(loaded_inputs, cmd_args, yml_args)  # sets outputs to self.
+            self.set_job_other_params(loaded_inputs, cmd_args, yml_args)  # sets outputs to self.
         self.cmd_args = cmd_args
         self.job_name, self.py_job, self.yml_args = job_name, py_job, yml_args
 
-    def set_job_name(self, cmd_args, job_file=None):
+    def set_job_main_params(self, cmd_args, job_file=None):
         job_name = cmd_args['job_name'] if cmd_args.get('job_name') else None
 
         if job_name:  # job_name is name from job_metadata.yml, takes priority if provided.
@@ -395,7 +394,7 @@ class Job_Args_Parser():
         # print('##----- job_name, py_job, yml_args:',job_name, py_job, yml_args)
         return job_name, py_job, yml_args
 
-    def set_job_params(self, loaded_inputs, cmd_args, yml_args):
+    def set_job_other_params(self, loaded_inputs, cmd_args, yml_args):
         """ Setting the params from yml or from commandline args if available."""  # TODO: change so class doesn't involve commandline args here, just yml.
 
         if cmd_args['storage'] == 's3' and self.job_file.startswith('jobs/'):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -368,16 +368,12 @@ class ETL_Base(object):
 
 
 class Job_Args_Parser():
-    # TODO: rewrite all. without relying on class attributes, without requiring args, and avoid rerunning it from within the job if ran from Flow()
     def __init__(self, cmd_args={}, job_file=None, get_all=True, loaded_inputs={}):
         self.job_name, self.py_job, self.yml_args = self.set_job_main_params(cmd_args, job_file)
         if get_all:
             args = self.set_job_other_params(loaded_inputs, cmd_args, self.yml_args)
             [setattr(self, key, value) for key, value in args.items()]  # attach vars to self.*
-            # map(lambda key, value: setattr(self, key, value), args.items()) # attach vars to self.*
-            # import ipdb; ipdb.set_trace()
-
-            # TODO: check later that it can be removed.
+            # TODO: check later that code below can be removed.
             # if cmd_args['storage'] == 's3' and job_file.startswith('jobs/'):
             #     # TODO: fix self.job_file, will break.
             #     self.job_file = CLUSTER_APP_FOLDER+job_file
@@ -386,7 +382,7 @@ class Job_Args_Parser():
     def set_job_main_params(self, cmd_args, job_file=None):
         job_name = cmd_args['job_name'] if cmd_args.get('job_name') else None
 
-        if job_name:  # job_name is name from job_metadata.yml, takes priority if provided.
+        if job_name:  # job_name (name from job_metadata.yml) takes priority if provided.
             yml_args = self.set_job_yml(cmd_args, job_name)
             py_job = yml_args['py_job'] if yml_args.get('py_job') else self.set_job_file_from_name(job_name)
         elif job_file:
@@ -471,7 +467,6 @@ class Job_Args_Parser():
             return {}
 
     def set_output(self, cmd_args, yml_args):
-        # import ipdb; ipdb.set_trace()
         output = self.set_generic_param(cmd_args, yml_args, param='output')
         if output is None and cmd_args.get('mode_no_io'):
             output = {}
@@ -480,38 +475,6 @@ class Job_Args_Parser():
             raise Exception("No output given")
         logger.info("output: '{}'".format(output))
         return output
-
-    # def set_frequency(self, cmd_args, yml_args):
-    #     if cmd_args.get('frequency'):
-    #         self.frequency = cmd_args['frequency']
-    #     elif cmd_args.get('job_param_file'):
-    #         self.frequency = yml_args.get('frequency')
-    #     else:
-    #         self.frequency = None
-
-    # def set_start_date(self, cmd_args, yml_args):
-    #     if cmd_args.get('start_date'):
-    #         self.start_date = cmd_args['start_date']  # will likely be loaded as string.
-    #     elif cmd_args.get('job_param_file'):
-    #         self.start_date = yml_args.get('start_date')
-    #     else:
-    #         self.start_date = None
-
-    # def set_copy_to_redshift(self, cmd_args, yml_args):
-    #     if cmd_args.get('copy_to_redshift'):
-    #         self.redshift_copy_params = cmd_args.get('copy_to_redshift')
-    #     elif cmd_args.get('job_param_file'):
-    #         self.redshift_copy_params = yml_args.get('copy_to_redshift')
-    #     else:
-    #         self.redshift_copy_params = None
-
-    # def set_copy_to_kafka(self, cmd_args, yml_args):
-    #     if cmd_args.get('copy_to_kafka'):
-    #         self.copy_to_kafka = cmd_args.get('copy_to_kafka')
-    #     elif cmd_args.get('job_param_file'):
-    #         self.copy_to_kafka = yml_args.get('copy_to_kafka')
-    #     else:
-    #         self.copy_to_kafka = None
 
     def set_db_creds(self, cmd_args, yml_args):
         if cmd_args.get('db_creds'):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -156,8 +156,7 @@ class ETL_Base(object):
         self.job_name = jargs.job_name  # name as written in jobs_metadata file, ex "examples/ex1_frameworked_job.py" or "examples/ex1_full_sql_job.sql"
         self.py_job = jargs.py_job  # name of python file supporting execution. Different from job_file for sql jobs or other generic python files.
         # self.app_name  # set earlier
-        if self.args.get('job_param_file'):
-            self.job_yml = jargs.yml_args
+        self.job_yml = jargs.yml_args
         self.INPUTS = jargs.inputs
         self.OUTPUT = jargs.output
         self.frequency = jargs.frequency
@@ -436,6 +435,8 @@ class Job_Args_Parser():
         meta_file = cmd_args.get('job_param_file')
         if meta_file == 'repo':
             meta_file = CLUSTER_APP_FOLDER+JOBS_METADATA_FILE if cmd_args['storage']=='s3' else JOBS_METADATA_LOCAL_FILE
+        elif meta_file is None:
+            return None
 
         yml = self.load_meta(meta_file)
         logger.info('Loaded job param file: ' + meta_file)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -383,7 +383,7 @@ class Job_Args_Parser():
         job_name = cmd_args.get('job_name')
         if job_name:  # job_name (name from job_metadata.yml) takes priority if provided.
             yml_args = self.set_job_yml(cmd_args, job_name)
-            py_job = yml_args['py_job'] if yml_args.get('py_job') else self.set_job_file_from_name(job_name)
+            py_job = yml_args['py_job'] if yml_args.get('py_job') else self.set_py_job_from_name(job_name)
         elif job_file:
             py_job = job_file
             job_name = self.set_job_name_from_file(job_file)
@@ -427,10 +427,10 @@ class Job_Args_Parser():
         logger.info("job_name: '{}', from job_file: '{}'".format(job_name, job_file))
         return job_name
 
-    def set_job_file_from_name(self, job_name):
-        job_file='jobs/{}'.format(job_name)
-        logger.info("job_name: '{}', and corresponding job_file: '{}'".format(job_name, job_file))
-        return job_file
+    def set_py_job_from_name(self, job_name):
+        py_job='jobs/{}'.format(job_name)
+        logger.info("job_name: '{}', and corresponding py_job: '{}'".format(job_name, py_job))
+        return py_job
 
     def set_job_yml(self, cmd_args, job_name):
         meta_file = cmd_args.get('job_param_file')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -676,12 +676,6 @@ class Commandliner():
             job = Job(self.args)
             deploy_args = job.jargs.get_deploy_args()
             app_args = job.jargs.get_app_args()
-            # job_file = job.set_job_file()
-            # jargs = Job_Args_Parser(cmd_args=self.args, job_file=job_file, get_all=True)
-            # deploy_args = {'aws_config_file': self.args.pop('aws_config_file'),
-            #                'aws_setup': self.args.pop('aws_setup'),
-            #                'leave_on': self.args.pop('leave_on'),
-            #                }
             self.launch_deploy_mode(deploy_args, app_args)  # TODO: make deployment args explicit + preprocess yml param upstread and remove it here.
 
     def set_commandline_args(self, args):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -127,12 +127,11 @@ class ETL_Base(object):
         logger.info("-------End job '{}'--------".format(self.jargs.job_name))
         return output
 
-    def etl_no_io(self, sc, sc_sql, loaded_inputs={}):
+    def etl_no_io(self, sc, sc_sql, loaded_inputs={}, jargs=None):
         """ Function to load inputs (including from live vars) and run transform. No output to disk.
         Having this code isolated is useful for cases with no I/O possible, like testing."""
+        self.jargs = jargs or self.jargs
         logger.info("etl args: {}".format(self.args))
-        if self.args.get('mode_no_io'):  # TODO: check if condition can be skipped, # TODO: pass jargs to etl_no_io so this can be removed.
-            self.set_job_params(loaded_inputs)
         self.sc = sc
         self.sc_sql = sc_sql
         self.app_name = sc.appName

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -369,10 +369,16 @@ class ETL_Base(object):
 
 class Job_Args_Parser():
     def __init__(self, cmd_args={}, job_file=None, get_all=True, loaded_inputs={}):
-        self.job_name, self.py_job, self.yml_args = self.set_job_main_params(cmd_args, job_file)
+        args = cmd_args.copy()
+        args['job_name'], args['py_job'], yml_args = self.set_job_main_params(cmd_args, job_file)
         if get_all:
-            args = self.set_job_other_params(loaded_inputs, cmd_args, self.yml_args)
-            [setattr(self, key, value) for key, value in args.items()]  # attach vars to self.*
+            args.update(self.set_job_other_params(loaded_inputs, cmd_args, yml_args))
+        [setattr(self, key, value) for key, value in args.items()]  # attach vars to self.*
+        logger.info("Job args: '{}'".format(pformat(args)))
+        # for other access to vars
+        self.merged_args = args
+        self.cmd_args = cmd_args
+        self.yml_args = yml_args
 
     def set_job_main_params(self, cmd_args, job_file=None):
         job_name = cmd_args.get('job_name')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -37,6 +37,7 @@ from configparser import ConfigParser
 import numpy as np
 #from sklearn.externals import joblib  # TODO: re-enable later after fixing lib versions.
 import gc
+from pprint import pformat
 import core.logger as log
 logger = log.setup_logging('Job')
 
@@ -104,7 +105,7 @@ class ETL_Base(object):
         output.show()
         count = output.count()
         logger.info('Output count: {}'.format(count))
-        logger.info("Output data types: {}".format([(fd.name, fd.dataType) for fd in output.schema.fields]))
+        logger.info("Output data types: {}".format(pformat([(fd.name, fd.dataType) for fd in output.schema.fields])))
         self.output_empty = count == 0
         if self.output_empty and self.jargs.is_incremental:
             logger.info("-------End job '{}', increment with empty output--------".format(self.jargs.job_name))
@@ -260,7 +261,7 @@ class ETL_Base(object):
         else:
             raise Exception("Unsupported input type '{}' for path '{}'. Supported types are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.SUPPORTED_TYPES))
 
-        logger.info("Input data types: {}".format([(fd.name, fd.dataType) for fd in sdf.schema.fields]))
+        logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))
         return sdf
 
     def load_mysql(self, input_name):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -36,8 +36,9 @@ import sys
 from configparser import ConfigParser
 import numpy as np
 #from sklearn.externals import joblib  # TODO: re-enable later after fixing lib versions.
-import core.logger as log
 import gc
+import core.logger as log
+logger = log.setup_logging('Job')
 
 
 JOBS_METADATA_FILE = 'conf/jobs_metadata.yml'
@@ -341,7 +342,7 @@ class ETL_Base(object):
         return df
 
     def copy_to_redshift_using_pandas(self, output, types):
-        # dependencies put here below to avoid loading heavy libraries when not needed (optional feature).
+        # import put here below to avoid loading heavy libraries when not needed (optional feature).
         from core.redshift_pandas import create_table
         from core.db_utils import cast_col
         df = output.toPandas()
@@ -353,7 +354,7 @@ class ETL_Base(object):
         del(df)
 
     def copy_to_redshift_using_spark(self, sdf):
-        # dependencies put here below to avoid loading heavy libraries when not needed (optional feature).
+        # import put here below to avoid loading heavy libraries when not needed (optional feature).
         from core.redshift_spark import create_table
         connection_profile = self.redshift_copy_params['creds']
         schema, name_tb= self.redshift_copy_params['table'].split('.')
@@ -915,6 +916,3 @@ class Flow():
         if len(tree.nodes()) >= 2:
             self.get_leafs(tree, leafs)
         return leafs + list(tree.nodes())
-
-
-logger = log.setup_logging('Job')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -436,7 +436,7 @@ class Job_Args_Parser():
         if meta_file == 'repo':
             meta_file = CLUSTER_APP_FOLDER+JOBS_METADATA_FILE if cmd_args['storage']=='s3' else JOBS_METADATA_LOCAL_FILE
         elif meta_file is None:
-            return None
+            return {}
 
         yml = self.load_meta(meta_file)
         logger.info('Loaded job param file: ' + meta_file)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -692,7 +692,15 @@ class Path_Handler():
 
 class Commandliner():
     def __init__(self, Job, **args):
-        self.set_commandline_args(args)
+        self.set_commandline_args(args)  # sets self.args TODO: make explicit
+        if Job is None:
+            assert self.args['job_name']
+            # import ipdb; ipdb.set_trace()
+            job_yml_parser = Job_Yml_Parser(self.args)
+            job_yml_parser.set_job_params(job_name=self.args['job_name'])
+            # args = job_yml_parser.update_args(args, job_yml_parser.job_file)
+            Job = Flow.get_job_class(job_yml_parser.py_job)
+
         if self.args['mode'] in ('local', 'localEMR'):
             self.launch_run_mode(Job, self.args)
         else:
@@ -725,6 +733,7 @@ class Commandliner():
         parser = argparse.ArgumentParser()
         parser.add_argument("-m", "--mode", choices=set(['local', 'EMR', 'localEMR', 'EMR_Scheduled', 'EMR_DataPipeTest']), help="Choose where to run the job. localEMR should not be used by user.")
         parser.add_argument("-j", "--job_param_file", help="Identify file to use. If 'repo', then default files from the repo are used. It can be set to 'False' to not load any file and provide all parameters through arguments.")
+        parser.add_argument("-n", "--job_name", help="Identify registry job to use.")
         parser.add_argument("--connection_file", help="Identify file to use. Default to repo one.")
         parser.add_argument("--jobs_folder", help="Identify the folder where job code is. Necessary if job code is outside the repo, i.e. if this is used as an external library. By default, uses the repo 'jobs/' folder.")
         parser.add_argument("-s", "--storage", choices=set(['local', 's3']), help="Choose 'local' (default) or 's3'.")
@@ -742,6 +751,7 @@ class Commandliner():
         defaults = {
                     'mode': 'local',
                     'job_param_file': 'repo',
+                    'job_name': None,
                     'connection_file': CONNECTION_FILE,
                     'jobs_folder': JOB_FOLDER,
                     'storage': 'local',

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -373,11 +373,6 @@ class Job_Args_Parser():
         if get_all:
             args = self.set_job_other_params(loaded_inputs, cmd_args, self.yml_args)
             [setattr(self, key, value) for key, value in args.items()]  # attach vars to self.*
-            # TODO: check later that code below can be removed.
-            # if cmd_args['storage'] == 's3' and job_file.startswith('jobs/'):
-            #     # TODO: fix self.job_file, will break.
-            #     self.job_file = CLUSTER_APP_FOLDER+job_file
-            #     logger.info("overwrote job_file needed for running on cluster: '{}'".format(self.job_file))  # TODO: integrate this patch directly in var assignment above when refactored, to avoid conflicting messages
 
     def set_job_main_params(self, cmd_args, job_file=None):
         job_name = cmd_args.get('job_name')
@@ -390,6 +385,10 @@ class Job_Args_Parser():
             yml_args = self.set_job_yml(cmd_args, job_name)
         else:
             raise Exception("Need to specify at least job_name or job_file")
+
+        # if cmd_args['storage'] == 's3' and py_job.startswith('jobs/'):
+        #     py_job = CLUSTER_APP_FOLDER+py_job
+        #     logger.info("overwrote py_job needed for running on cluster: '{}'".format(py_job))
 
         return job_name, py_job, yml_args
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -375,6 +375,12 @@ class Job_Args_Parser():
         job_name, py_job, yml_args = self.set_job_main_params(cmd_args, job_file)
         if get_all:
             self.set_job_other_params(loaded_inputs, cmd_args, yml_args)  # sets outputs to self.
+            # TODO: check later that it can be removed.
+            # if cmd_args['storage'] == 's3' and job_file.startswith('jobs/'):
+            #     # TODO: fix self.job_file, will break.
+            #     self.job_file = CLUSTER_APP_FOLDER+job_file
+            #     logger.info("overwrote job_file needed for running on cluster: '{}'".format(self.job_file))  # TODO: integrate this patch directly in var assignment above when refactored, to avoid conflicting messages
+
         self.cmd_args = cmd_args
         self.job_name, self.py_job, self.yml_args = job_name, py_job, yml_args
 
@@ -396,10 +402,6 @@ class Job_Args_Parser():
 
     def set_job_other_params(self, loaded_inputs, cmd_args, yml_args):
         """ Setting the params from yml or from commandline args if available."""  # TODO: change so class doesn't involve commandline args here, just yml.
-
-        if cmd_args['storage'] == 's3' and self.job_file.startswith('jobs/'):
-            self.job_file = CLUSTER_APP_FOLDER+self.job_file
-            logger.info("overwrote job_file needed for running on cluster: '{}'".format(self.job_file))  # TODO: integrate this patch directly in var assignment above when refactored, to avoid conflicting messages
 
         self.set_inputs(cmd_args, yml_args, loaded_inputs)
         self.set_output(cmd_args, yml_args)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -131,7 +131,6 @@ class ETL_Base(object):
         """ Function to load inputs (including from live vars) and run transform. No output to disk.
         Having this code isolated is useful for cases with no I/O possible, like testing."""
         self.jargs = jargs or self.jargs
-        logger.info("etl args: {}".format(self.args))
         self.sc = sc
         self.sc_sql = sc_sql
         self.app_name = sc.appName
@@ -149,21 +148,8 @@ class ETL_Base(object):
         raise NotImplementedError
 
     def set_job_params(self, loaded_inputs={}, job_file=None):
-        # TODO: redo without without the mapping.
-        job_file = self.set_job_file() # file where code is, could be .py or .sql. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
+        job_file = self.set_job_file() # file where code is, could be .py or .sql if ETL_Base subclassed. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
         self.jargs = Job_Args_Parser(cmd_args=self.args, job_file=job_file, get_all=True, loaded_inputs=loaded_inputs)  # has to be removed since already done in Commandliner()
-
-        # self.job_name = jargs.job_name  # name as written in jobs_metadata file, ex "examples/ex1_frameworked_job.py" or "examples/ex1_full_sql_job.sql"
-        # self.py_job = jargs.py_job  # name of python file supporting execution. Different from job_file for sql jobs or other generic python files.
-        # # self.app_name  # set earlier
-        # self.job_yml = jargs.yml_args
-        # self.INPUTS = jargs.inputs
-        # self.OUTPUT = jargs.output
-        # self.frequency = jargs.frequency
-        # self.redshift_copy_params = jargs.redshift_copy_params
-        # self.copy_to_kafka = jargs.copy_to_kafka
-        # self.db_creds = jargs.db_creds
-        # self.is_incremental = jargs.is_incremental
 
     def set_job_file(self):
         """ Returns the file being executed. For ex, when running "python some_job.py", this functions returns "some_job.py".
@@ -704,6 +690,7 @@ class Commandliner():
         parser.add_argument("-m", "--mode", choices=set(['local', 'EMR', 'localEMR', 'EMR_Scheduled', 'EMR_DataPipeTest']), help="Choose where to run the job. localEMR should not be used by user.")
         parser.add_argument("-j", "--job_param_file", help="Identify file to use. If 'repo', then default files from the repo are used. It can be set to 'False' to not load any file and provide all parameters through arguments.")
         parser.add_argument("-n", "--job_name", help="Identify registry job to use.")
+        parser.add_argument("-q", "--sql_file", help="Path to an sql file to execute.")
         parser.add_argument("--connection_file", help="Identify file to use. Default to repo one.")
         parser.add_argument("--jobs_folder", help="Identify the folder where job code is. Necessary if job code is outside the repo, i.e. if this is used as an external library. By default, uses the repo 'jobs/' folder.")
         parser.add_argument("-s", "--storage", choices=set(['local', 's3']), help="Choose 'local' (default) or 's3'.")
@@ -722,6 +709,7 @@ class Commandliner():
                     'mode': 'local',
                     'job_param_file': 'repo',
                     'job_name': None,
+                    'sql_file': None,
                     'connection_file': CONNECTION_FILE,
                     'jobs_folder': JOB_FOLDER,
                     'storage': 'local',

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -1,0 +1,26 @@
+from core.etl_utils import ETL_Base, Commandliner
+
+
+# class Job(ETL_Base):
+#     """To run/deploy any jobs, using --job_name arg."""
+#
+#     # def set_job_file(self):
+#     #     job_file=self.args['job_name']
+#     #     logger.info("job_file: '{}'".format(job_file))
+#     #     return job_file
+#
+#     def transform(self, **kwargs):
+#         import ipdb; ipdb.set_trace()
+#         return df
+
+
+# class SQLCommandliner(Commandliner):
+#     @staticmethod
+#     def define_commandline_args():
+#         parser = Commandliner.define_commandline_args()
+#         parser.add_argument("-h", "--job_name", help="Name of ")
+#         return parser
+
+if __name__ == "__main__":
+    # SQLCommandliner(Job)
+    Commandliner(Job=None)

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -1,26 +1,3 @@
-from core.etl_utils import ETL_Base, Commandliner
+from core.etl_utils import Commandliner
 
-
-# class Job(ETL_Base):
-#     """To run/deploy any jobs, using --job_name arg."""
-#
-#     # def set_job_file(self):
-#     #     job_file=self.args['job_name']
-#     #     logger.info("job_file: '{}'".format(job_file))
-#     #     return job_file
-#
-#     def transform(self, **kwargs):
-#         import ipdb; ipdb.set_trace()
-#         return df
-
-
-# class SQLCommandliner(Commandliner):
-#     @staticmethod
-#     def define_commandline_args():
-#         parser = Commandliner.define_commandline_args()
-#         parser.add_argument("-h", "--job_name", help="Name of ")
-#         return parser
-
-if __name__ == "__main__":
-    # SQLCommandliner(Job)
-    Commandliner(Job=None)
+Commandliner(Job=Non 

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -1,3 +1,3 @@
 from core.etl_utils import Commandliner
 
-Commandliner(Job=Non 
+Commandliner(Job=None)

--- a/core/mysql_job.py
+++ b/core/mysql_job.py
@@ -13,7 +13,7 @@ class Mysql_Job(ETL_Base):
         output spark df."""
         query_str = query_str.replace('%', '%%')  # replace necessary for pymysql parser
         logger.info('Query string:\n' + query_str)
-        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
+        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage, creds=self.jargs.connection_file)
         creds_section = self.jargs.yml_args['api_inputs']['api_creds']
         logger.info('The query is using the credential section:' + creds_section)
         pdf = query_mysql(query_str, db=creds_section, creds_or_file=creds)

--- a/core/mysql_job.py
+++ b/core/mysql_job.py
@@ -14,7 +14,7 @@ class Mysql_Job(ETL_Base):
         query_str = query_str.replace('%', '%%')  # replace necessary for pymysql parser
         logger.info('Query string:\n' + query_str)
         creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
-        creds_section = self.job_yml['api_inputs']['api_creds']
+        creds_section = self.jargs.yml_args['api_inputs']['api_creds']
         logger.info('The query is using the credential section:' + creds_section)
         pdf = query_mysql(query_str, db=creds_section, creds_or_file=creds)
         sdf = pdf_to_sdf(pdf, self.OUTPUT_TYPES, self.sc, self.sc_sql)

--- a/core/oracle_sql_job.py
+++ b/core/oracle_sql_job.py
@@ -18,7 +18,7 @@ class Job(ETL_Base):
     #     if inputs_in_args:
     #         self.INPUTS = {key.replace('input_', ''): val for key, val in self.args.iteritems() if key.startswith('input_')}
     #     elif self.args.get('job_param_file'):  # should be before loaded_inputs to use yaml if available. Later function load_inputs uses both self.INPUTS and loaded_inputs, so not incompatible.
-    #         self.INPUTS = self.job_yml.get('inputs') or {}
+    #         self.INPUTS = self.jargs.yml_args.get('inputs') or {}
     #     # elif loaded_inputs:
     #     #     self.INPUTS = {key: {'path': val, 'type': 'df'} for key, val in loaded_inputs.iteritems()}
     #     else:

--- a/core/oracle_sql_job.py
+++ b/core/oracle_sql_job.py
@@ -8,29 +8,16 @@ class Job(ETL_Base):
     """To run/deploy sql jobs, requires --sql_file arg."""
 
     def set_job_file(self):
-        job_file=self.args['sql_file']
+        job_file=self.jargs.cmd_args['sql_file']
         # logger.info("job_file: '{}'".format(job_file))
         return job_file
 
-    ## Can't use that anymore since set_inputs now in separate class "Job_Args_Parser". This change is only necessary "if inputs_in_args". TODO: find other way to integrate it.
-    # def set_inputs(self, loaded_inputs=None):  # TODO: can't be used that way now.
-    #     inputs_in_args = len([item for item in self.args.keys() if item.startswith('input_')]) >= 1
-    #     if inputs_in_args:
-    #         self.INPUTS = {key.replace('input_', ''): val for key, val in self.args.iteritems() if key.startswith('input_')}
-    #     elif self.args.get('job_param_file'):  # should be before loaded_inputs to use yaml if available. Later function load_inputs uses both self.INPUTS and loaded_inputs, so not incompatible.
-    #         self.INPUTS = self.jargs.yml_args.get('inputs') or {}
-    #     # elif loaded_inputs:
-    #     #     self.INPUTS = {key: {'path': val, 'type': 'df'} for key, val in loaded_inputs.iteritems()}
-    #     else:
-    #         logger.info("No input given, through commandline nor yml file.")
-    #         self.INPUTS = {}
-
     def transform(self, **ignored):
-        sql_file = self.args['sql_file']
+        sql_file = self.jargs.cmd_args['sql_file']
         sql = self.read_sql_file(sql_file)
         sql = self.update_sql_file(sql)
         self.OUTPUT_TYPES = self.get_output_types_from_sql(sql)
-        cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'])
+        cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage)
 
         print "Running query: \n", sql
         pdf = query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles) # for testing locally: from libs.analysis_toolkit.query_helper import process_and_cache; pdf = process_and_cache('test', 'data/', lambda : query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles), force_rerun=False)

--- a/core/oracle_sql_job.py
+++ b/core/oracle_sql_job.py
@@ -12,7 +12,7 @@ class Job(ETL_Base):
         # logger.info("job_file: '{}'".format(job_file))
         return job_file
 
-    ## Can't use that anymore since set_inputs now in separate class "Job_Yml_Parser". This change is only necessary "if inputs_in_args". TODO: find other way to integrate it.
+    ## Can't use that anymore since set_inputs now in separate class "Job_Args_Parser". This change is only necessary "if inputs_in_args". TODO: find other way to integrate it.
     # def set_inputs(self, loaded_inputs=None):  # TODO: can't be used that way now.
     #     inputs_in_args = len([item for item in self.args.keys() if item.startswith('input_')]) >= 1
     #     if inputs_in_args:

--- a/core/sql_job.py
+++ b/core/sql_job.py
@@ -5,12 +5,12 @@ class Job(ETL_Base):
     """To run/deploy sql jobs, using --sql_file arg."""
 
     def set_job_file(self):
-        job_file=self.args['sql_file']
+        job_file=self.jargs.cmd_args['sql_file']
         # logger.info("job_file: '{}'".format(job_file))
         return job_file
 
     def transform(self, **ignored):
-        sql = self.read_sql_file(self.args['sql_file'])
+        sql = self.read_sql_file(self.jargs.cmd_args['sql_file'])
         df = self.query(sql)
         return df
 
@@ -22,13 +22,5 @@ class Job(ETL_Base):
         return sql
 
 
-class SQLCommandliner(Commandliner):
-    @staticmethod
-    def define_commandline_args():
-        parser = Commandliner.define_commandline_args()
-        parser.add_argument("-q", "--sql_file", help="path of sql file to run")
-        return parser
-
-
 if __name__ == "__main__":
-    SQLCommandliner(Job)
+    Commandliner(Job)

--- a/jobs/examples/ex5_input_from_oracle_job.py
+++ b/jobs/examples/ex5_input_from_oracle_job.py
@@ -12,7 +12,7 @@ class Job(ETL_Base):
         }
 
     def transform(self):
-        cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'])
+        cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage)
         query_str = """
             SELECT session_id, count_events
             FROM test_ex5_pyspark_job

--- a/jobs/examples/ex9_mysql_job.py
+++ b/jobs/examples/ex9_mysql_job.py
@@ -10,7 +10,7 @@ logger = log.setup_logging('Job')
 class Job(ETL_Base):
     def transform(self):
         creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
-        creds_section = self.job_yml['db_inputs']['creds']
+        creds_section = self.jargs.yml_args['db_inputs']['creds']
         db = creds[creds_section]
         url = 'jdbc:mysql://{host}:{port}/{service}'.format(host=db['host'], port=db['port'], service=db['service'])
         dbtable = 'some.table'

--- a/jobs/examples/ex9_mysql_job.py
+++ b/jobs/examples/ex9_mysql_job.py
@@ -9,7 +9,7 @@ logger = log.setup_logging('Job')
 
 class Job(ETL_Base):
     def transform(self):
-        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
+        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage, creds=self.jargs.connection_file)
         creds_section = self.jargs.yml_args['db_inputs']['creds']
         db = creds[creds_section]
         url = 'jdbc:mysql://{host}:{port}/{service}'.format(host=db['host'], port=db['port'], service=db['service'])

--- a/jobs/examples/ex9_redshift_job.py
+++ b/jobs/examples/ex9_redshift_job.py
@@ -10,7 +10,7 @@ logger = log.setup_logging('Job')
 class Job(ETL_Base):
     def transform(self, some_events):
         creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
-        creds_section = self.job_yml['copy_to_redshift']['creds']
+        creds_section = self.jargs.yml_args['copy_to_redshift']['creds']
         db = creds[creds_section]
         url = 'jdbc:redshift://{host}:{port}/{service}'.format(host=db['host'], port=db['port'], service=db['service'])
         dbtable = 'sandbox.test_ex9_redshift'

--- a/jobs/examples/ex9_redshift_job.py
+++ b/jobs/examples/ex9_redshift_job.py
@@ -9,7 +9,7 @@ logger = log.setup_logging('Job')
 
 class Job(ETL_Base):
     def transform(self, some_events):
-        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.args['storage'], creds=self.args.get('connection_file'))
+        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage, creds=self.jargs.connection_file)
         creds_section = self.jargs.yml_args['copy_to_redshift']['creds']
         db = creds[creds_section]
         url = 'jdbc:redshift://{host}:{port}/{service}'.format(host=db['host'], port=db['port'], service=db['service'])

--- a/tests/core/etl_utils_test.py
+++ b/tests/core/etl_utils_test.py
@@ -1,5 +1,5 @@
 import pytest
-from core.etl_utils import ETL_Base, Job_Yml_Parser, Flow, Commandliner, LOCAL_APP_FOLDER
+from core.etl_utils import ETL_Base, Job_Args_Parser, Flow, Commandliner, LOCAL_APP_FOLDER
 
 class Test_ETL_Base(object):
 
@@ -23,9 +23,9 @@ class Test_ETL_Base(object):
         job_file = ETL_Base().copy_to_oracle(output, types)
         assert job_file.replace(LOCAL_APP_FOLDER, '') == 'core/etl_utils.py' # file is the one that starts execution, typically the job python file.
 
-class Test_Job_Yml_Parser(object):
+class Test_Job_Args_Parser(object):
     def test_set_job_name(self):
-        yml = Job_Yml_Parser()
+        yml = Job_Args_Parser()
         yml.set_job_name('jobs/some/file.py')
         assert yml.job_name == 'some/file.py'
 


### PR DESCRIPTION
One python script can now be reused for several jobs. Will be useful for ex to have 1 mysql extraction python job, reused for a lot of different tables (with name of table passed as args in job_metadata.yml). 

Involved lots of changes:
 * major update to job arguments, now using jargs giving the args based on cmd line and yml inputs, and allowing them to be set from the cmd line or the yml params (when they were compartmented before). Cleaner, less code redundancy. Will be easier to add more params.
 * deploy.py don't rely on jargs (called 'yml' in that file before) anymore, just to deploy_args and app_args dicts. 
 * now avoid loading jargs twice for a standard job as was the case before (jargs can be passed if build upstream)
 * created launcher.py to run jobs from job_metadata.yml directly. It will load the python script specified in job_metadata.yml and execute it.

Unrelated:
 * better code to deal with EMR spark submit args.
 * cleaner logs with pprint
 * bump spark mysql driver version
 * added --sql_file as standard arg.

cc @JoanRamos 