### PR TITLE
Check pks + schemas saved in repo + git in logs + others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tmp/
 data/
 extra/
+schemas/
 metastore_db/
 derby.log
 conf/aws_config.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ derby.log
 conf/aws_config.cfg
 conf/connections.cfg
 libs/python_db_connectors/credentials.cfg
+conf/git_config.yml
+launch_env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ metastore_db/
 derby.log
 conf/aws_config.cfg
 conf/connections.cfg
-libs/python_db_connectors/credentials.cfg
 conf/git_config.yml
+libs/python_db_connectors/credentials.cfg
 launch_env.sh

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -150,6 +150,7 @@ common_params:
       jobs_folder:      jobs/
       load_connectors: all
       enable_redshift_push: True
+      manage_git_info: True
     EMR_dev:
       base_path: s3://dev-spark  # don't add '/' at the end
       schema: sandbox
@@ -159,9 +160,11 @@ common_params:
       jobs_folder:      jobs/
       load_connectors: all
       enable_redshift_push: False
+      manage_git_info: True
     local_dev:
       base_path: ./data  # don't add '/' at the end
       schema: sandbox
       load_connectors: none
       aws_config_file:  none
       enable_redshift_push: False
+      manage_git_info: False

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -150,6 +150,7 @@ common_params:
       jobs_folder:      jobs/
       load_connectors: all
       enable_redshift_push: True
+      save_schemas: False
       manage_git_info: True
     EMR_dev:
       base_path: s3://dev-spark  # don't add '/' at the end
@@ -160,6 +161,7 @@ common_params:
       jobs_folder:      jobs/
       load_connectors: all
       enable_redshift_push: False
+      save_schemas: False
       manage_git_info: True
     local_dev:
       base_path: ./data  # don't add '/' at the end
@@ -167,4 +169,5 @@ common_params:
       load_connectors: none
       aws_config_file:  none
       enable_redshift_push: False
+      save_schemas: True
       manage_git_info: False

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -149,6 +149,7 @@ common_params:
       aws_setup:        dev
       jobs_folder:      jobs/
       load_connectors: all
+      enable_redshift_push: True
     EMR_dev:
       base_path: s3://dev-spark  # don't add '/' at the end
       schema: sandbox
@@ -157,8 +158,10 @@ common_params:
       aws_setup:        dev
       jobs_folder:      jobs/
       load_connectors: all
+      enable_redshift_push: False
     local_dev:
       base_path: ./data  # don't add '/' at the end
       schema: sandbox
       load_connectors: none
       aws_config_file:  none
+      enable_redshift_push: False

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -19,6 +19,7 @@ import botocore
 from botocore.exceptions import ClientError
 import uuid
 import json
+from pprint import pformat
 from configparser import ConfigParser
 from shutil import copyfile
 import core.etl_utils as eu
@@ -36,8 +37,8 @@ class DeployPySparkScriptOnAws(object):
 
     def __init__(self, deploy_args, app_args):
 
-        logger.info("etl deploy_args: {}".format(deploy_args))
-        logger.info("etl app_args: {}".format(app_args))
+        logger.info("etl deploy_args: \n{}".format(pformat(deploy_args)))
+        logger.info("etl app_args: \n{}".format(pformat(app_args)))
         aws_setup = deploy_args['aws_setup']
         config = ConfigParser()
         assert os.path.isfile(deploy_args['aws_config_file'])
@@ -380,7 +381,7 @@ class DeployPySparkScriptOnAws(object):
             "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
             "--packages={}".format(eu.PACKAGES_EMR),
             "--jars={}".format(eu.JARS),
-            eu.CLUSTER_APP_FOLDER+app_file if app_file.startswith(eu.JOB_FOLDER) else eu.CLUSTER_APP_FOLDER+eu.JOB_FOLDER+app_file,
+            eu.CLUSTER_APP_FOLDER+app_file,
             "--mode=localEMR",
             "--storage=s3",
             '--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER+eu.JOBS_METADATA_FILE),

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -178,7 +178,7 @@ class DeployPySparkScriptOnAws(object):
 
         # Add config files
         t_file.add(self.app_args['job_param_file'], arcname=eu.JOBS_METADATA_FILE)
-        t_file.add(base+'conf/git_config.yml', arcname='conf/git_config.yml') # TODO: remove hardcoding
+        t_file.add('conf/git_config.yml', arcname='conf/git_config.yml') # TODO: remove hardcoding
 
         # ./core files
         files = os.listdir(base+'core/')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -113,12 +113,8 @@ class ETL_Base(object):
         end_time = time()
         elapsed = end_time - start_time
         logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
-        # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
-
-        # import ipdb; ipdb.set_trace()
         meta.save_yaml(self.jargs.job_name)
-
-
+        # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
         if self.jargs.merged_args.get('copy_to_redshift') and self.jargs.enable_redshift_push:
             self.copy_to_redshift_using_spark(output)  # to use pandas: self.copy_to_redshift_using_pandas(output, self.OUTPUT_TYPES)
@@ -412,14 +408,10 @@ class ETL_Base(object):
 class Meta_Builder():
     TYPES_FOLDER = 'types/'
     def generate_meta(self, loaded_datasets, output):
-        # from collections import OrderedDict
         yml = {'inputs':{}}  # OrderedDict()
         for key, value in loaded_datasets.items():
-            # types = [(fd.name, fd.dataType) for fd in value.schema.fields]
-            # types =
             yml['inputs'][key] = {fd.name: fd.dataType.__str__() for fd in value.schema.fields}
         yml['output'] = {fd.name: fd.dataType.__str__() for fd in output.schema.fields}
-        # import ipdb; ipdb.set_trace()
         self.yml = yml
 
     def save_yaml(self, job_name):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -404,7 +404,7 @@ class ETL_Base(object):
 
 
 class Meta_Builder():
-    TYPES_FOLDER = 'types/'
+    TYPES_FOLDER = 'schemas/'
     def generate_meta(self, loaded_datasets, output):
         yml = {'inputs':{}}  # OrderedDict()
         for key, value in loaded_datasets.items():

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -143,7 +143,6 @@ class ETL_Base(object):
         meta.generate_meta(loaded_datasets, output)
         return output, meta
 
-
     def transform(self, **app_args):
         """ The function that needs to be overriden by each specific job."""
         raise NotImplementedError
@@ -152,7 +151,6 @@ class ETL_Base(object):
         """ jargs means job args. Function called only if running the job directly, i.e. "python some_job.py"""
         job_file = self.set_job_file() # file where code is, could be .py or .sql if ETL_Base subclassed. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
         job_name = Job_Yml_Parser.set_job_name_from_file(job_file)
-        # pre_jargs['job_args']['job_name'] = job_name  # necessary to get Job_Args_Parser() loading yml properly
         return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], job_name=job_name, loaded_inputs=loaded_inputs)  # set yml_args=None so loading yml is handled in Job_Args_Parser()
 
     def set_job_file(self):
@@ -495,9 +493,10 @@ class Job_Args_Parser():
         If yml_args not provided, it will go and get it.
         Sets of params:
             - defaults_args: defaults command line args, as defined in define_commandline_args()
-            - yml_args: args for specific job from yml
+            - yml_args: args for specific job from yml. If = None, it will rebuild it using job_name param.
             - job_args: args passed to "Commandliner(Job, **args)" in each job file
             - cmd_args: args passed in commandline, like "python some_job.py --some_args=xxx", predefined in define_commandline_args() or not
+            - job_name: to use only when yml_args is set to None, to specify what section of the yml to pick.
         """
         if yml_args is None:
             # Getting merged args, without yml (order matters)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -31,6 +31,8 @@ import numpy as np
 import gc
 from pprint import pformat
 import smtplib, ssl
+from pyspark.sql.window import Window
+from pyspark.sql import functions as F
 import core.logger as log
 logger = log.setup_logging('Job')
 
@@ -392,14 +394,14 @@ class ETL_Base(object):
             return True
 
     def identify_non_unique_pks(self, df, pks):
-        from pyspark.sql.window import Window
-        from pyspark.sql import functions as F
+        # from pyspark.sql.window import Window
+        # from pyspark.sql import functions as F
 
         # import ipdb; ipdb.set_trace()
         windowSpec  = Window.partitionBy([F.col(item) for item in pks])
         df = df.withColumn('_count_pk', F.count('*').over(windowSpec)) \
             .where(F.col('_count_pk') >= 2)
-        # df.repartition(1).write.mode('overwrite').option("header", "true").csv('data/sandbox/non_unique_test/')
+        # Debug: df.repartition(1).write.mode('overwrite').option("header", "true").csv('data/sandbox/non_unique_test/')
         return df
 
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -396,7 +396,7 @@ class ETL_Base(object):
             logger.error("PKs not unique. count={}, count_pk={}".format(count, count_pk))
             return False
         else:
-            logger.info("Fields given are PKs. count=count_pk={}".format(count))
+            logger.info("Confirmed fields given are PKs (i.e. unique). count=count_pk={}".format(count))
             return True
 
     def identify_non_unique_pks(self, df, pks):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -115,7 +115,7 @@ class ETL_Base(object):
         logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
         # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
-        if self.jargs.merged_args.get('copy_to_redshift'):
+        if self.jargs.merged_args.get('copy_to_redshift') and self.jargs.enable_redshift_push:
             self.copy_to_redshift_using_spark(output)  # to use pandas: self.copy_to_redshift_using_pandas(output, self.OUTPUT_TYPES)
         if self.jargs.merged_args.get('copy_to_kafka'):
             self.push_to_kafka(output, self.OUTPUT_TYPES)
@@ -757,6 +757,7 @@ class Commandliner():
                     'aws_setup': 'dev',
                     # 'leave_on': False, # only set from commandline
                     # 'push_secrets': False, # only set from commandline
+                    'enable_redshift_push': True,
                     }
         return parser, defaults
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -63,7 +63,6 @@ class ETL_Base(object):
             git_yml = Git_Config_Manager().get_config()
             [git_yml.pop(key, None) for key in ('diffs', 'diffs_yaetos')]
             logger.info('Git info {}'.format(git_yml))
-            # import ipdb; ipdb.set_trace()
 
     def etl(self, sc, sc_sql):
         """ Main function. If incremental, reruns ETL process multiple time until
@@ -442,16 +441,11 @@ class Git_Config_Manager():
         last_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('ascii')
         diffs = subprocess.check_output(['git', 'diff', 'HEAD']).strip().decode('ascii')
         is_dirty = True if diffs else False
-        # import ipdb; ipdb.set_trace()
-        # path_var = os.pathsep.join(os.environ.get('PATH', os.defpath), some_dir)
-        # path_var = os.environ.get('PATH', os.defpath)
-        # env = dict(os.environ, PATH=path_var)
         branch_yaetos = subprocess.check_output(['git', 'describe', '--all'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
         last_commit_yaetos = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
         diffs_yaetos = subprocess.check_output(['git', 'diff', 'HEAD'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
         is_dirty_yaetos = True if diffs_yaetos else False
 
-        # import ipdb; ipdb.set_trace()
         config = {'branch':branch,
                   'last_commit':last_commit,
                   'diffs':diffs,
@@ -461,7 +455,6 @@ class Git_Config_Manager():
                   'diffs_yaetos':diffs_yaetos,
                   'is_dirty_yaetos':is_dirty_yaetos
                   }
-        # self.config = config
         return config
 
     def is_git_controlled(self):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -394,10 +394,6 @@ class ETL_Base(object):
             return True
 
     def identify_non_unique_pks(self, df, pks):
-        # from pyspark.sql.window import Window
-        # from pyspark.sql import functions as F
-
-        # import ipdb; ipdb.set_trace()
         windowSpec  = Window.partitionBy([F.col(item) for item in pks])
         df = df.withColumn('_count_pk', F.count('*').over(windowSpec)) \
             .where(F.col('_count_pk') >= 2)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -119,7 +119,8 @@ class ETL_Base(object):
         end_time = time()
         elapsed = end_time - start_time
         logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
-        meta.save_yaml(self.jargs.job_name)
+        if self.jargs.save_schemas:
+            meta.save_yaml(self.jargs.job_name)
         # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
         if self.jargs.merged_args.get('copy_to_redshift') and self.jargs.enable_redshift_push:
@@ -847,7 +848,9 @@ class Commandliner():
                     'aws_setup': 'dev',
                     # 'leave_on': False, # only set from commandline
                     # 'push_secrets': False, # only set from commandline
+                    # Not added in command line args:
                     'enable_redshift_push': True,
+                    'save_schemas': False,
                     'manage_git_info': False,
                     }
         return parser, defaults

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -401,10 +401,10 @@ class ETL_Base(object):
         return df
 
 
-class Meta_Builder():
+class Meta_Builder():  # TODO: rename to "schemas" here and below
     TYPES_FOLDER = 'schemas/'
     def generate_meta(self, loaded_datasets, output):
-        yml = {'inputs':{}}  # OrderedDict()
+        yml = {'inputs':{}}
         for key, value in loaded_datasets.items():
             yml['inputs'][key] = {fd.name: fd.dataType.__str__() for fd in value.schema.fields}
         yml['output'] = {fd.name: fd.dataType.__str__() for fd in output.schema.fields}

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -432,7 +432,6 @@ class Git_Config_Manager():
             self.save_yaml(config)
         else:
             config = self.get_config_from_file()
-        # import ipdb; ipdb.set_trace()
         return config
 
     def get_config_from_git(self):
@@ -459,9 +458,7 @@ class Git_Config_Manager():
 
     def is_git_controlled(self):
         import subprocess
-        #out = subprocess.check_output(["git", "rev-parse"]).strip().decode('ascii')
-        out = os.system('git rev-parse')
-        # import ipdb; ipdb.set_trace()
+        out = os.system('git rev-parse')  # not using subprocess.check_output() to avoid crash if it fails.
         if out == 0:
             return True
         else:
@@ -477,6 +474,7 @@ class Git_Config_Manager():
             return Job_Yml_Parser.load_meta(self.FNAME)
         else:
             return False
+
 
 class Job_Yml_Parser():
     """Functions to load and parse yml, and functions to get job_name, which is the key to the yml info."""

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -157,16 +157,16 @@ class ETL_Base(object):
 
     def set_jargs(self, pre_jargs, loaded_inputs={}):
         """ jargs means job args. Function called only if running the job directly, i.e. "python some_job.py"""
-        job_file = self.set_job_file() # file where code is, could be .py or .sql if ETL_Base subclassed. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
-        job_name = Job_Yml_Parser.set_job_name_from_file(job_file)
+        py_job = self.set_py_job()
+        job_name = Job_Yml_Parser.set_job_name_from_file(py_job)
         return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], job_name=job_name, loaded_inputs=loaded_inputs)  # set yml_args=None so loading yml is handled in Job_Args_Parser()
 
-    def set_job_file(self):
+    def set_py_job(self):
         """ Returns the file being executed. For ex, when running "python some_job.py", this functions returns "some_job.py".
         Only gives good output when the job is launched that way."""
-        job_file = inspect.getsourcefile(self.__class__)
-        logger.info("job_file: '{}'".format(job_file))
-        return job_file
+        py_job = inspect.getsourcefile(self.__class__)
+        logger.info("py_job: '{}'".format(py_job))
+        return py_job
 
     def load_inputs(self, loaded_inputs):
         app_args = {}
@@ -886,7 +886,7 @@ class Flow():
         # load all job classes and run them
         df = {}
         for job_name in leafs:
-            logger.info('About to run : {}'.format(job_name))
+            logger.info('About to run job_name: {}'.format(job_name))
             # Get yml
             yml_args = Job_Yml_Parser(job_name, launch_jargs.job_param_file, launch_jargs.mode).yml_args
             # Get loaded_inputs

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -61,6 +61,7 @@ class ETL_Base(object):
         self.jargs = self.set_jargs(pre_jargs, loaded_inputs) if not jargs else jargs
         if self.jargs.manage_git_info:
             git_yml = Git_Config_Manager().get_config()
+            [git_yml.pop(key, None) for key in ('diffs', 'diffs_yaetos')]
             logger.info('Git info {}'.format(git_yml))
             # import ipdb; ipdb.set_trace()
 
@@ -442,9 +443,24 @@ class Git_Config_Manager():
         diffs = subprocess.check_output(['git', 'diff', 'HEAD']).strip().decode('ascii')
         is_dirty = True if diffs else False
         # import ipdb; ipdb.set_trace()
+        # path_var = os.pathsep.join(os.environ.get('PATH', os.defpath), some_dir)
+        # path_var = os.environ.get('PATH', os.defpath)
+        # env = dict(os.environ, PATH=path_var)
+        branch_yaetos = subprocess.check_output(['git', 'describe', '--all'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
+        last_commit_yaetos = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
+        diffs_yaetos = subprocess.check_output(['git', 'diff', 'HEAD'], cwd=LOCAL_APP_FOLDER).strip().decode('ascii')
+        is_dirty_yaetos = True if diffs_yaetos else False
+
+        # import ipdb; ipdb.set_trace()
         config = {'branch':branch,
                   'last_commit':last_commit,
-                  'is_dirty':is_dirty}
+                  'diffs':diffs,
+                  'is_dirty':is_dirty,
+                  'branch_yaetos':branch_yaetos,
+                  'last_commit_yaetos':last_commit_yaetos,
+                  'diffs_yaetos':diffs_yaetos,
+                  'is_dirty_yaetos':is_dirty_yaetos
+                  }
         # self.config = config
         return config
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -386,7 +386,7 @@ class ETL_Base(object):
             logger.info('Email sent to {}'.format(recipient))
 
     def send_job_failure_email(self, error_msg):
-        message = """Subject: [Data Pipeline Failure] {name}\n\nA Data pipeline named '{name}' failed.\nError message:\n{error}\n\nPlease check AWS Data Pipeline.""".format(name=self.jargs.job_name, error=error_msg)
+        message = """Subject: [Data Pipeline Failure] {name}\n\nA Data pipeline named '{name}' failed.\nError message:\n{error}\n\nPlease check logs in AWS.""".format(name=self.jargs.job_name, error=error_msg)
         self.send_msg(message)
 
     def check_pk(self, df, pks):
@@ -458,7 +458,7 @@ class Job_Yml_Parser():
     @staticmethod
     def set_py_job_from_name(job_name):
         py_job='jobs/{}'.format(job_name)
-        logger.info("job_name: '{}', and corresponding py_job: '{}'".format(job_name, py_job))
+        logger.info("job_name: '{}', and corresponding py_job: '{}'".format(job_name, py_job))  # TODO: fix py_job being .sql file in EMR runs (even though jobs work) and job_name here Doesn't match job_name in param list.
         return py_job
 
     def set_job_yml(self, job_name, job_param_file, mode):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -420,7 +420,7 @@ class Meta_Builder():  # TODO: rename to "schemas" here and below
         fname = self.TYPES_FOLDER + job_name+'.yaml'
         os.makedirs(os.path.dirname(fname), exist_ok=True)
         with open(fname, 'w') as file:
-            documents = yaml.dump(self.yml, file)
+            ignored = yaml.dump(self.yml, file)
 
 class Git_Config_Manager():
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -62,7 +62,7 @@ class ETL_Base(object):
         self.jargs = self.set_jargs(pre_jargs, loaded_inputs) if not jargs else jargs
         if self.jargs.manage_git_info:
             git_yml = Git_Config_Manager().get_config(LOCAL_APP_FOLDER)
-            [git_yml.pop(key, None) for key in ('diffs', 'diffs_yaetos')]
+            [git_yml.pop(key, None) for key in ('diffs_current', 'diffs_yaetos')]
             logger.info('Git info {}'.format(git_yml))
 
     def etl(self, sc, sc_sql):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -880,6 +880,8 @@ class Flow():
         logger.info('Sequence of jobs to be run: {}'.format(leafs))
         logger.info('-'*80)
         logger.info('-')
+        launch_jargs.cmd_args.pop('job_name', None)  # removing since it should be pulled from yml and not be overriden by cmd_args.
+        launch_jargs.job_args.pop('job_name', None)  # same
 
         # load all job classes and run them
         df = {}

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -61,8 +61,8 @@ class ETL_Base(object):
         self.loaded_inputs = loaded_inputs
         self.jargs = self.set_jargs(pre_jargs, loaded_inputs) if not jargs else jargs
         if self.jargs.manage_git_info:
-            git_yml = Git_Config_Manager().get_config(LOCAL_APP_FOLDER)
-            [git_yml.pop(key, None) for key in ('diffs_current', 'diffs_yaetos')]
+            git_yml = Git_Config_Manager().get_config(mode=self.jargs.mode, local_app_folder=LOCAL_APP_FOLDER, cluster_app_folder=CLUSTER_APP_FOLDER)
+            [git_yml.pop(key, None) for key in ('diffs_current', 'diffs_yaetos') if git_yml]
             logger.info('Git info {}'.format(git_yml))
 
     def etl(self, sc, sc_sql):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -152,8 +152,8 @@ class ETL_Base(object):
         """ jargs means job args. Function called only if running the job directly, i.e. "python some_job.py"""
         job_file = self.set_job_file() # file where code is, could be .py or .sql if ETL_Base subclassed. ex "jobs/examples/ex1_frameworked_job.py" or "jobs/examples/ex1_full_sql_job.sql"
         job_name = Job_Yml_Parser.set_job_name_from_file(job_file)
-        pre_jargs['job_args']['job_name'] = job_name  # necessary to get Job_Args_Parser() loading yml properly
-        return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], loaded_inputs=loaded_inputs)  # set yml_args=None so loading yml is handled in Job_Args_Parser()
+        # pre_jargs['job_args']['job_name'] = job_name  # necessary to get Job_Args_Parser() loading yml properly
+        return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], job_name=job_name, loaded_inputs=loaded_inputs)  # set yml_args=None so loading yml is handled in Job_Args_Parser()
 
     def set_job_file(self):
         """ Returns the file being executed. For ex, when running "python some_job.py", this functions returns "some_job.py".
@@ -490,7 +490,7 @@ class Job_Args_Parser():
 
     DEPLOY_ARGS_LIST = ['aws_config_file', 'aws_setup', 'leave_on', 'push_secrets', 'frequency', 'start_date', 'email']
 
-    def __init__(self, defaults_args, yml_args, job_args, cmd_args, loaded_inputs={}):
+    def __init__(self, defaults_args, yml_args, job_args, cmd_args, job_name=None, loaded_inputs={}):
         """Mix all params, add more and tweak them when needed (like depending on storage type, execution mode...).
         If yml_args not provided, it will go and get it.
         Sets of params:
@@ -504,6 +504,7 @@ class Job_Args_Parser():
             args = defaults_args.copy()
             args.update(job_args)
             args.update(cmd_args)
+            args.update({'job_name':job_name} if job_name else {})
             assert 'job_name' in args.keys()
             yml_args = Job_Yml_Parser(args['job_name'], args['job_param_file'], args['mode']).yml_args
 

--- a/core/git_utils.py
+++ b/core/git_utils.py
@@ -12,7 +12,7 @@ class Git_Config_Manager():
     def get_config(self, mode, **kwargs):
         if mode in ('local', 'EMR', 'EMR_Scheduled'):
             config = self.get_config_from_git(kwargs['local_app_folder'])
-            # self.save_yaml(config)
+            # For debug: self.save_yaml(config)
         elif mode == 'localEMR':
             config = self.get_config_from_file(kwargs['cluster_app_folder'])
         else:

--- a/core/git_utils.py
+++ b/core/git_utils.py
@@ -26,10 +26,10 @@ class Git_Config_Manager():
         diffs_yaetos = subprocess.check_output(['git', 'diff', 'HEAD'], cwd=local_app_folder).strip().decode('ascii')
         is_dirty_yaetos = True if diffs_yaetos else False
 
-        config = {'branch':branch,
-                  'last_commit':last_commit,
-                  'diffs':diffs,
-                  'is_dirty':is_dirty,
+        config = {'branch_current':branch,
+                  'last_commit_current':last_commit,
+                  'diffs_current':diffs,
+                  'is_dirty_current':is_dirty,
                   'branch_yaetos':branch_yaetos,
                   'last_commit_yaetos':last_commit_yaetos,
                   'diffs_yaetos':diffs_yaetos,

--- a/core/git_utils.py
+++ b/core/git_utils.py
@@ -1,0 +1,57 @@
+import yaml
+import os
+import subprocess
+
+
+class Git_Config_Manager():
+
+    FNAME = 'conf/git_config.yml'
+
+    def get_config(self, local_app_folder):
+        if self.is_git_controlled():
+            config = self.get_config_from_git(local_app_folder)
+            self.save_yaml(config)
+        else:
+            config = self.get_config_from_file()
+        return config
+
+    def get_config_from_git(self, local_app_folder):
+
+        branch = subprocess.check_output(["git", "describe", '--all']).strip().decode('ascii')  # to get if dirty, add '--dirty'.
+        last_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('ascii')
+        diffs = subprocess.check_output(['git', 'diff', 'HEAD']).strip().decode('ascii')
+        is_dirty = True if diffs else False
+        branch_yaetos = subprocess.check_output(['git', 'describe', '--all'], cwd=local_app_folder).strip().decode('ascii')
+        last_commit_yaetos = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=local_app_folder).strip().decode('ascii')
+        diffs_yaetos = subprocess.check_output(['git', 'diff', 'HEAD'], cwd=local_app_folder).strip().decode('ascii')
+        is_dirty_yaetos = True if diffs_yaetos else False
+
+        config = {'branch':branch,
+                  'last_commit':last_commit,
+                  'diffs':diffs,
+                  'is_dirty':is_dirty,
+                  'branch_yaetos':branch_yaetos,
+                  'last_commit_yaetos':last_commit_yaetos,
+                  'diffs_yaetos':diffs_yaetos,
+                  'is_dirty_yaetos':is_dirty_yaetos
+                  }
+        return config
+
+    def is_git_controlled(self):
+        import subprocess
+        out = os.system('git rev-parse')  # not using subprocess.check_output() to avoid crash if it fails.
+        if out == 0:
+            return True
+        else:
+            return False  # will send "fatal: not a git repository" to stderr
+
+    def save_yaml(self, config):
+        os.makedirs(os.path.dirname(self.FNAME), exist_ok=True)
+        with open(self.FNAME, 'w') as file:
+            documents = yaml.dump(config, file)
+
+    def get_config_from_file():
+        if os.path.isfile(self.FNAME):
+            return Job_Yml_Parser.load_meta(self.FNAME)
+        else:
+            return False

--- a/core/git_utils.py
+++ b/core/git_utils.py
@@ -10,7 +10,7 @@ class Git_Config_Manager():
     def get_config(self, local_app_folder):
         if self.is_git_controlled():
             config = self.get_config_from_git(local_app_folder)
-            self.save_yaml(config)
+            # self.save_yaml(config)
         else:
             config = self.get_config_from_file()
         return config
@@ -48,10 +48,12 @@ class Git_Config_Manager():
     def save_yaml(self, config):
         os.makedirs(os.path.dirname(self.FNAME), exist_ok=True)
         with open(self.FNAME, 'w') as file:
-            documents = yaml.dump(config, file)
+            ignored = yaml.dump(config, file)
 
     def get_config_from_file():
         if os.path.isfile(self.FNAME):
-            return Job_Yml_Parser.load_meta(self.FNAME)
+            with open(self.FNAME, 'r') as stream:
+                yml = yaml.load(stream)
+            return yml
         else:
             return False

--- a/libs/analysis_toolkit/query_helper.py
+++ b/libs/analysis_toolkit/query_helper.py
@@ -176,7 +176,7 @@ def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_del
         item1 = compare1[ii]
         item2 = compare2[ii]
         assert item1!=item2
-        df_joined['_delta_'+item1] = df_joined.apply(lambda row: (row[item1] if not np.isnan(row[item1]) else 0.0)-(row[item2] if not np.isnan(row[item2]) else 0.0), axis=1) # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
+        df_joined['_delta_'+item1] = df_joined.apply(lambda row: (row[item1] if not pd.isna(row[item1]) else 0.0)-(row[item2] if not pd.isna(row[item2]) else 0.0), axis=1) # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
         df_joined['_delta_'+item1+'_%'] = df_joined.apply(check_delta, axis=1)
         df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas']==True and row['_delta_'+item1+'_%']<threshold, axis=1)
     np.seterr(divide='raise')


### PR DESCRIPTION
Main:
 * added code to check_pks() and to identify_non_unique_pks().
 * new feature to pull git info into logs to track, enabled with new param `manage_git_info`. Saves the config in file `conf/git_config.yml` and ships the file to S3 with code package to have the git version read from there (for EMR runs) and shown in logs there too. Code in new `core/git_utils.py` file.
 * Fixed jargs when there are dependencies (Job_Args_Parser) where it was showing the wrong job_name, even though it was executing the right job. This fix was necessary to set the names for the new schema feature above. 
 * new feature to save job i/o schemas to repo, enabled with new param `save_schemas`. They go in new folder './schemas/', with format 'some_job_name.yml'.

Others
 * refactored email notification to be usable from within jobs for any purpose, made more generic.
 * disabled push to redshift when in dev, thanks to new param `enable_redshift_push` 

cc @JoanRamos 