### PR TITLE
Prod code

### DIFF
--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -116,7 +116,7 @@ class ETL_Base(object):
             # TODO: look at saving output empty table instead of skipping output.
             return output
 
-        self.save(output, self.start_dt)
+        self.save_output(output, self.start_dt)
         end_time = time()
         elapsed = end_time - start_time
         logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
@@ -294,31 +294,40 @@ class ETL_Base(object):
     def get_max_timestamp(self, df):
         return df.agg({self.jargs.output['inc_field']: "max"}).collect()[0][0]
 
-    def save(self, output, now_dt, path=None):
-        if path is None:
-            path = Path_Handler(self.jargs.output['path'], self.jargs.base_path).expand_now(now_dt)
-        self.path = path
+    def save_output(self, output, now_dt=None):
+        self.path = self.save(output=output,
+                  path=self.jargs.output['path'],
+                  base_path=self.jargs.base_path,
+                  type=self.jargs.output['type'],
+                  now_dt=now_dt,
+                  is_incremental=self.jargs.is_incremental,
+                  file_tag=self.jargs.merged_args.get('file_tag'))  # TODO: make param standard in cmd_args ?
 
-        if self.jargs.output['type'] == 'None':
+    def save(self, output, path, base_path, type, now_dt=None, is_incremental=None, file_tag=None):
+        """Used to save output to disk. Can be used too inside jobs to output 2nd output for testing."""
+        path = Path_Handler(path, base_path).expand_now(now_dt)
+
+        if type == 'None':
             logger.info('Did not write output to disk')
             return None
 
-        if self.jargs.is_incremental:
+        if is_incremental:
             current_time = now_dt.strftime('%Y%m%d_%H%M%S_utc')  # no use of now_dt to make it updated for each inc.
-            file_tag = ('_' + self.jargs.merged_args.get('file_tag')) if self.jargs.merged_args.get('file_tag') else ""  # TODO: make that param standard in cmd_args ?
+            file_tag = ('_' + file_tag) if file_tag else ""  # TODO: make that param standard in cmd_args ?
             path += 'inc_{}{}/'.format(current_time, file_tag)
 
         # TODO: deal with cases where "output" is df when expecting rdd, or at least raise issue in a cleaner way.
-        if self.jargs.output['type'] == 'txt':
+        if type == 'txt':
             output.saveAsTextFile(path)
-        elif self.jargs.output['type'] == 'parquet':
+        elif type == 'parquet':
             output.write.parquet(path)
-        elif self.jargs.output['type'] == 'csv':
+        elif type == 'csv':
             output.write.option("header", "true").csv(path)
         else:
             raise Exception("Need to specify supported output type, either txt, parquet or csv.")
 
         logger.info('Wrote output to ' + path)
+        return path
 
     def save_metadata(self, elapsed):
         fname = self.path + '_metadata.txt'

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -505,7 +505,7 @@ class Job_Yml_Parser():
 
 class Job_Args_Parser():
 
-    DEPLOY_ARGS_LIST = ['aws_config_file', 'aws_setup', 'leave_on', 'push_secrets', 'frequency', 'start_date', 'email']
+    DEPLOY_ARGS_LIST = ['aws_config_file', 'aws_setup', 'leave_on', 'push_secrets', 'frequency', 'start_date', 'email', 'deploy_mode']
 
     def __init__(self, defaults_args, yml_args, job_args, cmd_args, job_name=None, loaded_inputs={}):
         """Mix all params, add more and tweak them when needed (like depending on storage type, execution mode...).
@@ -818,10 +818,11 @@ class Commandliner():
                     'aws_setup': 'dev',
                     # 'leave_on': False, # only set from commandline
                     # 'push_secrets': False, # only set from commandline
-                    # Not added in command line args:
+                    #-- Not added in command line args:
                     'enable_redshift_push': True,
                     'save_schemas': False,
                     'manage_git_info': False,
+                    'deploy_mode': 'dev',
                     }
         return parser, defaults
 


### PR DESCRIPTION
New arg 'deploy_mode', can be used to push code to unique S3 folder when set to 'prod'. This allow having all prod jobs to use same code. Setting it to 'dev' does the same as before, push the code to separate S3 folder. It can lead to inconsistent code across jobs with dependencies. Pipeline names now include whether it is prod or dev.

Other: split save() in 2 functions, one save_output() and 1 save(), which is kept generic so it can be used insides jobs (to save other datasets from within a job).