### PR TITLE
Deploy code only

### DIFF
--- a/core/deploy.py
+++ b/core/deploy.py
@@ -627,10 +627,10 @@ def terminate(error_message=None):
     exit()
 
 def deploy_standalone():
+    # TODO: refactor below to use 'deploy' arg to trigger all deploy features, instead of new 'deploy_option' set below.
     job_args = {
         # --- regular job params ---
         'job_param_file': None,
-        # 'deploy':'EMR',
         'mode':'dev_EMR',
         'output': {'path':'n_a', 'type':'csv'},
         'job_name': 'n_a',

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -626,8 +626,7 @@ def terminate(error_message=None):
     logger.critical('The script is now terminating')
     exit()
 
-
-if __name__ == "__main__":
+def deploy_standalone():
     job_args = {
         # --- regular job params ---
         'job_param_file': None,
@@ -639,18 +638,12 @@ if __name__ == "__main__":
         'deploy_option':'deploy_code_only',
     }
 
-    # defaults_args, cmd_args = eu.Commandliner(eu.ETL_Base).set_commandline_args()
     parser, defaults_args = eu.Commandliner.define_commandline_args()
     cmd_args = eu.Commandliner.set_commandline_args(parser)
     jargs = eu.Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, loaded_inputs={})
     deploy_args = jargs.get_deploy_args()
     app_args=jargs.get_app_args()
 
-    # import ipdb; ipdb.set_trace()
-    # print('command line: ', ' '.join(sys.argv))
-    # job_name = sys.argv[1] if len(sys.argv) > 1 else 'examples/ex1_raw_job_cluster.py'  # TODO: move to 'jobs/examples/ex1_raw_job_cluster.py'
-    # deploy_args = {'leave_on': True, 'aws_config_file':eu.AWS_CONFIG_FILE, 'aws_setup':'dev'}
-    # app_args = {'job_name':job_name, 'py_job':py_job, 'deploy':'EMR'}
     if jargs.deploy_option == 'deploy_job': # can be used to push random code to cluster
         # TODO: fails to create a new cluster but works to add a step to an existing cluster.
         DeployPySparkScriptOnAws(deploy_args, app_args).run()
@@ -669,10 +662,11 @@ if __name__ == "__main__":
         deploy_all_scheduled() # TODO: needs more testing.
 
     elif jargs.deploy_option == 'package_code_locally_only':  # only for debuging
-        # deploy_args = {'aws_config_file':eu.AWS_CONFIG_FILE, 'aws_setup':'dev'}
-        # app_args = {'job_param_file':'conf/jobs_metadata_local.yml',
-        #             'jobs_folder':'jobs',
-        #             }
         deployer = DeployPySparkScriptOnAws(deploy_args, app_args)  # TODO: should remove need for some of these inputs as they are not required by tar_python_scripts()
         pipelines = deployer.tar_python_scripts()
         print('#--- Finished packaging ---')
+    return True
+
+
+if __name__ == "__main__":
+    deploy_standalone()

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -75,8 +75,16 @@ class DeployPySparkScriptOnAws(object):
             self.run_direct()
         elif self.deploy_args['deploy'] in ('EMR_Scheduled', 'EMR_DataPipeTest'):
             self.run_aws_data_pipeline()
+        elif self.deploy_args['deploy'] in ('code'):
+            self.run_push_code()
         else:
             raise Exception("Shouldn't get here.")
+
+    def run_push_code(self):
+        print("Pushing code only")
+        self.s3_ops(self.session)
+        if self.deploy_args.get('push_secrets', False):
+            self.push_secrets(creds_or_file=self.app_args['connection_file'])  # TODO: fix privileges to get creds in dev env
 
     def run_direct(self):
         """Useful to run job on cluster without bothering with aws data pipeline. Also useful to add steps to existing cluster."""

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -832,7 +832,7 @@ class Commandliner():
         # Executing or deploying
         if job.jargs.deploy in ('none'):  # when executing job code
             self.launch_run_mode(job)
-        elif job.jargs.deploy in ('EMR', 'EMR_Scheduled'):  # when deploying to AWS for execution there
+        elif job.jargs.deploy in ('EMR', 'EMR_Scheduled', 'code'):  # when deploying to AWS for execution there
             self.launch_deploy_mode(job.jargs.get_deploy_args(), job.jargs.get_app_args())
 
     def set_commandline_args(self):
@@ -848,7 +848,7 @@ class Commandliner():
     def define_commandline_args():
         # Defined here separatly for overridability.
         parser = argparse.ArgumentParser()
-        parser.add_argument("-d", "--deploy", choices=set(['none', 'EMR', 'EMR_Scheduled', 'EMR_DataPipeTest']), help="Choose where to run the job.")
+        parser.add_argument("-d", "--deploy", choices=set(['none', 'EMR', 'EMR_Scheduled', 'EMR_DataPipeTest', 'code']), help="Choose where to run the job.")
         parser.add_argument("-m", "--mode", choices=set(['dev_local', 'dev_EMR', 'prod_EMR']), help="Choose which set of params to use from jobs_metadata.yml file.")
         parser.add_argument("-j", "--job_param_file", help="Identify file to use. It can be set to 'False' to not load any file and provide all parameters through job or command line arguments.")
         parser.add_argument("-n", "--job_name", help="Identify registry job to use.")

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -819,7 +819,8 @@ class Path_Handler():
 
 class Commandliner():
     def __init__(self, Job, **job_args):
-        defaults_args, cmd_args = self.set_commandline_args()
+        parser, defaults_args = self.define_commandline_args()
+        cmd_args = self.set_commandline_args(parser)
 
         # Building "job", which will include all job args.
         if Job is None:  # when job run from "python launcher.py --job_name=some_name_from_job_metadata_file"
@@ -835,14 +836,15 @@ class Commandliner():
         elif job.jargs.deploy in ('EMR', 'EMR_Scheduled', 'code'):  # when deploying to AWS for execution there
             self.launch_deploy_mode(job.jargs.get_deploy_args(), job.jargs.get_app_args())
 
-    def set_commandline_args(self):
+    @staticmethod
+    def set_commandline_args(parser):
         """Command line arguments take precedence over function ones."""
-        parser, defaults = self.define_commandline_args()
+        # parser, defaults = self.define_commandline_args()
         cmd_args, cmd_unknown_args = parser.parse_known_args()
         cmd_args = {key: value for (key, value) in cmd_args.__dict__.items() if value is not None}
         cmd_unknown_args = dict([item[2:].split('=') for item in cmd_unknown_args])  # imposes for unknown args to be defined with '=' and to start with '--'
         cmd_args.update(cmd_unknown_args)
-        return defaults, cmd_args
+        return cmd_args
 
     @staticmethod
     def define_commandline_args():

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -839,7 +839,6 @@ class Commandliner():
     @staticmethod
     def set_commandline_args(parser):
         """Command line arguments take precedence over function ones."""
-        # parser, defaults = self.define_commandline_args()
         cmd_args, cmd_unknown_args = parser.parse_known_args()
         cmd_args = {key: value for (key, value) in cmd_args.__dict__.items() if value is not None}
         cmd_unknown_args = dict([item[2:].split('=') for item in cmd_unknown_args])  # imposes for unknown args to be defined with '=' and to start with '--'


### PR DESCRIPTION
Added way to deploy code only, i.e. without executing any job, using `--deploy=code`, either from the deploy.py directly, or from any job (makes less sense since it may impact more than 1 job, when sent to production folder) 