### PR TITLE
Make _created_at optional + fix libs

### DIFF
--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -336,7 +336,7 @@ class ETL_Base(object):
             .load()
 
     def get_previous_output_max_timestamp(self):
-        path = self.jargs.output['path']
+        path = self.jargs.output['path']  # implies output path is incremental (no "{now}" in string.)
         path += '*' # to go into subfolders
         try:
             df = self.load_data_from_files(name='output', path=path, type=self.jargs.output['type'])

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -151,7 +151,8 @@ class ETL_Base(object):
         loaded_datasets = self.load_inputs(loaded_inputs)
         output = self.transform(**loaded_datasets)
         if output and self.jargs.output['type'] in self.TABULAR_TYPES:
-            output = output.withColumn('_created_at', F.lit(self.start_dt))
+            if self.jargs.add_created_at=='true':
+                output = output.withColumn('_created_at', F.lit(self.start_dt))
             output.cache()
             schemas = Schema_Builder()
             schemas.generate_schemas(loaded_datasets, output)
@@ -894,6 +895,7 @@ class Commandliner():
                     'enable_redshift_push': True,
                     'save_schemas': False,
                     'manage_git_info': False,
+                    'add_created_at': 'true',  # set as string to be overrideable in cmdline.
                     }
         return parser, defaults
 

--- a/core/scripts/setup_master.sh
+++ b/core/scripts/setup_master.sh
@@ -6,6 +6,9 @@
 s3_bucket="$1"
 s3_bucket_scripts="$s3_bucket/scripts.tar.gz"
 
+# export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+python3 -m pip install -U pip
+
 # Update awscli here as required by "aws s3 cp ..."
 # TODO: pip install -r requirements.txt # see related note in setup_nodes.sh
 sudo pip-3.6 install awscli==1.16.67 # depends on botocore from 1.12.57
@@ -13,9 +16,11 @@ sudo pip-3.6 install scikit-learn==0.20.0  # TODO: remove when using req file
 sudo pip-3.6 install statsmodels==0.9.0  # TODO: remove when using req file
 sudo pip-3.6 install kafka-python==1.4.7
 sudo pip-3.6 install jsonschema==3.0.2
-sudo pip-3.6 install koalas==1.3.0
+# sudo pip-3.6 install koalas==1.3.0  # fails installing now. TODO: check.
 # DB and API libs
 sudo pip-3.6 install soql==1.0.2  # Necessary for simple-salesforce
+sudo pip-3.6 install setuptools-rust==0.11.6  # Necessary for simple-salesforce
+sudo pip-3.6 install cryptography==3.3.1  # Necessary for simple-salesforce, to avoid simple-salesforce loading 3.4.4 causing pbs.
 sudo pip-3.6 install simple-salesforce==1.10.1
 sudo pip-3.6 install pymysql==0.9.3
 sudo pip-3.6 install psycopg2-binary==2.8.5  # necesary for sqlalchemy-redshift, psycopg2==2.8.5 fails installing.

--- a/core/scripts/setup_master.sh
+++ b/core/scripts/setup_master.sh
@@ -6,8 +6,6 @@
 s3_bucket="$1"
 s3_bucket_scripts="$s3_bucket/scripts.tar.gz"
 
-# export CRYPTOGRAPHY_DONT_BUILD_RUST=1
-python3 -m pip install -U pip
 
 # Update awscli here as required by "aws s3 cp ..."
 # TODO: pip install -r requirements.txt # see related note in setup_nodes.sh
@@ -19,7 +17,7 @@ sudo pip-3.6 install jsonschema==3.0.2
 # sudo pip-3.6 install koalas==1.3.0  # fails installing now. TODO: check.
 # DB and API libs
 sudo pip-3.6 install soql==1.0.2  # Necessary for simple-salesforce
-sudo pip-3.6 install setuptools-rust==0.11.6  # Necessary for simple-salesforce
+# sudo pip-3.6 install setuptools-rust==0.11.6  # Necessary for simple-salesforce
 sudo pip-3.6 install cryptography==3.3.1  # Necessary for simple-salesforce, to avoid simple-salesforce loading 3.4.4 causing pbs.
 sudo pip-3.6 install simple-salesforce==1.10.1
 sudo pip-3.6 install pymysql==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ flake8==3.7.9
 stripe==2.50.0
 soql==1.0.2
 # setuptools-rust==0.11.6
-# cryptography==3.3.1
+cryptography==3.3.1
 simple-salesforce==1.10.1
 pymysql==0.9.3
 psycopg2-binary==2.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,12 @@ jsonschema==3.0.2
 flake8==3.7.9
 stripe==2.50.0
 soql==1.0.2
+# setuptools-rust==0.11.6
+# cryptography==3.3.1
 simple-salesforce==1.10.1
 pymysql==0.9.3
 psycopg2-binary==2.8.5
 sqlalchemy-redshift==0.7.7
 stripe==2.50.0
-koalas==1.3.0
+# koalas==1.3.0
 py4j==0.10.9.1


### PR DESCRIPTION
Make _created_at optional so we can remove it when we want to compare datasets for ex.

Fix libs since simple-salesforce lib install started to fail due to cryptography lib dependency.