### PR TITLE
Incremental updates

### DIFF
--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -1040,7 +1040,7 @@ class Commandliner():
                     'jobs_folder': JOB_FOLDER,
                     'storage': 'local',
                     # 'dependencies': False, # only set from commandline
-                    'rerun_criteria': 'both',
+                    'rerun_criteria': 'last_date',
                     # 'boxed_dependencies': False,  # only set from commandline
                     'load_connectors': 'all',
                     # 'output.type': 'csv',  # skipped on purpose to avoid setting it if not set in cmd line.

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -132,16 +132,17 @@ class ETL_Base(object):
             # TODO: add process time in that case.
             return None
 
-        logger.info('Output sample:')
-        try:
-            output.show()
-        except Exception as e:
-            logger.info("Warning: Failed showing table sample with error '{}'.".format(e))
-            pass
-        count = output.count()
-        logger.info('Output count: {}'.format(count))
-        logger.info("Output data types: {}".format(pformat([(fd.name, fd.dataType) for fd in output.schema.fields])))
-        self.output_empty = count == 0
+        if not self.jargs.no_fw_cache:
+            logger.info('Output sample:')
+            try:
+                output.show()
+            except Exception as e:
+                logger.info("Warning: Failed showing table sample with error '{}'.".format(e))
+                pass
+            count = output.count()
+            logger.info('Output count: {}'.format(count))
+            logger.info("Output data types: {}".format(pformat([(fd.name, fd.dataType) for fd in output.schema.fields])))
+            self.output_empty = count == 0
 
         self.save_output(output, self.start_dt)
         end_time = time()
@@ -1009,6 +1010,7 @@ class Commandliner():
                     'save_schemas': False,
                     'manage_git_info': False,
                     'add_created_at': 'true',  # set as string to be overrideable in cmdline.
+                    'no_fw_cache': False,
                     }
         return parser, defaults
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -210,7 +210,6 @@ class ETL_Base(object):
         raise NotImplementedError
 
     def get_last_run_period_daily(self, sc, sc_sql):
-        # first_day = self.jargs.merged_args['first_day']
         previous_output_max_timestamp = self.get_previous_output_max_timestamp(sc, sc_sql)
         last_run_period  = previous_output_max_timestamp.strftime("%Y-%m-%d") if previous_output_max_timestamp else None  # TODO: if get_output_max_timestamp()=None, means new build, so should delete instance in DBs.
         return last_run_period
@@ -294,19 +293,6 @@ class ETL_Base(object):
     def filter_incremental_inputs_period(self, app_args):
         """Filter based on period defined in. Simple but can be a pb if late arriving data or dependencies not run.
         Inputs filtered inside source database will be filtered again."""
-        # min_dt = self.get_previous_output_max_timestamp() if len(app_args.keys()) > 0 else None
-        #
-        # # Get latest timestamp in common across incremental inputs
-        # maxes = []
-        # for item in app_args.keys():
-        #     input_is_tabular = self.jargs.inputs[item]['type'] in self.TABULAR_TYPES
-        #     inc = self.jargs.inputs[item].get('inc_field', None)
-        #     if input_is_tabular and inc:
-        #         max_dt = app_args[item].agg({inc: "max"}).collect()[0][0]
-        #         maxes.append(max_dt)
-        # max_dt = min(maxes) if len(maxes)>0 else None
-
-        # Filter
         for item in app_args.keys():
             input_is_tabular = self.jargs.inputs[item]['type'] in self.TABULAR_TYPES
             inc = self.jargs.inputs[item].get('inc_field', None)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -147,8 +147,8 @@ class ETL_Base(object):
         self.save_output(output, self.start_dt)
         end_time = time()
         elapsed = end_time - start_time
-        logger.info('Process time to complete (post save to file but pre copy to db if any): {} s'.format(elapsed))
-        if self.jargs.save_schemas:
+        logger.info('Process time to complete (post save to file but pre copy to db if any, also may not include processing if output not saved): {} s'.format(elapsed))
+        if self.jargs.save_schemas and schemas:
             schemas.save_yaml(self.jargs.job_name)
         # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
@@ -160,6 +160,9 @@ class ETL_Base(object):
             self.push_to_kafka(output, self.OUTPUT_TYPES)
 
         output.unpersist()
+        end_time = time()
+        elapsed = end_time - start_time
+        logger.info('Process time to complete job (post db copies if any): {} s'.format(elapsed))
         logger.info("-------End job '{}'--------".format(self.jargs.job_name))
         return output
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -98,7 +98,7 @@ class ETL_Base(object):
                     period = periods[0]
                     logger.info('Period to be loaded in this run: {}'.format(period))
                     self.final_inc = period == periods[-1]
-                    self.last_attempted_period = period  # TODO: rename to attempted_period
+                    self.period = period  # to be captured in etl_one_pass if needed.
                     self.jargs.merged_args['file_tag'] = period
                     output = self.etl_one_pass(sc, sc_sql, loaded_inputs)
             else:
@@ -367,7 +367,7 @@ class ETL_Base(object):
                 .load()
         else:
             inc_field = self.jargs.inputs[input_name]['inc_field']
-            period = self.last_attempted_period
+            period = self.period
             query_str = "select * from {} where {} = '{}'".format(dbtable, inc_field, period)
             logger.info('Pulling table from mysql with query_str "{}"'.format(query_str))
             # TODO: check if it should use com.mysql.cj.jdbc.Driver instead as above
@@ -402,7 +402,7 @@ class ETL_Base(object):
                 .load()
         else:
             inc_field = self.jargs.inputs[input_name]['inc_field']
-            period = self.last_attempted_period
+            period = self.period
             query_str = "select * from {} where {} = '{}'".format(dbtable, inc_field, period)
             logger.info('Pulling table from Clickhouse with query_str "{}"'.format(query_str))
             sdf = self.sc_sql.read \


### PR DESCRIPTION
made incremental sequencial (not dependent on MOTM, not dependent of whether there is data or not in the increments.). Simpler. Still a pb when rerunning when output has data. It will duplicate last period for now. to be fixed.

Fixed inc loading when increment exits. It was reloading from scratch since function in loading try-except didn't have spark context and was always failing. Fix first increment day that was starting after first_day input (and not ON first day input ) when starting from scratch. var renames to clarify. Tested in local.

Other:
 * Adding ability to skip part of framework that involve caching (leading to less verbose logs with no table sample and count). New param: "no_fw_cache".
 * some var renaming
 * added elapsed time to end of job to log.