### PR TITLE
Force 1node clusters

### DIFF
--- a/core/definition_standalone_cluster.json
+++ b/core/definition_standalone_cluster.json
@@ -1,0 +1,169 @@
+{
+  "objects": [
+    {
+      "name": "EmrActivityObjYaetos",
+      "id": "EmrActivityObj",
+      "type": "EmrActivity",
+      "step": "#{myEmrStep}",
+      "runsOn": {"ref": "EmrClusterObj"}
+    },
+    {
+      "name": "EmrClusterObjYaetos",
+      "id": "EmrClusterObj",
+      "type": "EmrCluster",
+      "subnetId": "#{mySubnet}",
+      "taskInstanceType": "#{myTaskInstanceType}",
+      "taskInstanceCount": "#{myTaskInstanceCount}",
+      "bootstrapAction": "#{myBootstrapAction}",
+      "keyPair": "#{myEC2KeyPair}",
+      "masterInstanceType": "#{myMasterInstanceType}",
+      "releaseLabel": "#{myEMRReleaseLabel}",
+      "terminateAfter": "300 Minutes",
+      "applications": "spark",
+      "configuration": {"ref": "spark-env" }
+    },
+    {
+      "name": "spark-env",
+      "id": "spark-env",
+      "type": "EmrConfiguration",
+      "classification": "spark-env",
+      "configuration": {"ref": "export" }
+    },
+    {
+      "name": "export",
+      "id": "export",
+      "type": "EmrConfiguration",
+      "classification": "export",
+      "property": {"ref": "pyspark_python" }
+    },
+    {
+      "name": "pyspark_python",
+      "id": "pyspark_python",
+      "type": "Property",
+      "key": "PYSPARK_PYTHON",
+      "value": "/usr/bin/python3"
+    },
+    {
+      "name": "DefaultYaetos",
+      "id": "Default",
+      "failureAndRerunMode": "CASCADE",
+      "resourceRole": "DataPipelineDefaultResourceRole",
+      "role": "DataPipelineDefaultRole",
+      "pipelineLogUri": "#{myPipelineLogUri}",
+      "scheduleType": "#{myScheduleType}",
+      "schedule": {"ref": "DefaultSchedule"}
+    },
+    {
+      "name": "CustomScheduleYaetos",
+      "id": "DefaultSchedule",
+      "type": "Schedule",
+      "period": "#{myPeriod}",
+      "startDateTime": "#{myStartDateTime}"
+    }
+  ],
+  "parameters": [
+    {
+      "id": "myEC2KeyPair",
+      "type": "String",
+      "helpText": "An existing EC2 key pair to SSH into the master node of the EMR cluster as the user \"hadoop\".",
+      "description": "EC2 key pair",
+      "optional": "true"
+    },
+    {
+      "id": "myPipelineLogUri",
+      "type": "String",
+      "helpText": "blah",
+      "description": "blah bla",
+      "optional": "true"
+    },
+    {
+      "id": "myScheduleType",
+      "type": "String",
+      "helpText": "blah",
+      "description": "values seen: ONDEMAND, cron",
+      "optional": "true"
+    },
+    {
+      "id": "myPeriod",
+      "type": "String",
+      "helpText": "blah",
+      "description": "blah blah",
+      "optional": "true"
+    },
+    {
+      "id": "myStartDateTime",
+      "type": "String",
+      "helpText": "blah",
+      "description": "blah blah",
+      "optional": "true"
+    },
+    {
+      "id": "myEmrStep",
+      "type": "String",
+      "helpLink": "https://docs.aws.amazon.com/console/datapipeline/emrsteps",
+      "watermark": "s3://myBucket/myPath/myStep.jar,firstArg,secondArg",
+      "helpText": "A step is a unit of work you submit to the cluster. You can specify one or more steps",
+      "description": "EMR step(s)",
+      "isArray": "true"
+    },
+    {
+      "id": "myTaskInstanceType",
+      "type": "String",
+      "helpText": "Task instances run Hadoop tasks.",
+      "description": "Task node instance type",
+      "optional": "true"
+    },
+    {
+      "id": "myEMRReleaseLabel",
+      "type": "String",
+      "default": "emr-5.26.0",
+      "helpText": "Determines the base configuration of the instances in your cluster, including the Hadoop version.",
+      "description": "EMR Release Label"
+    },
+    {
+      "id": "myTaskInstanceCount",
+      "type": "Integer",
+      "description": "Task node instance count",
+      "optional": "true"
+    },
+    {
+      "id": "mySubnet",
+      "type": "string",
+      "description": "Subnet for EC2 master node to connect to external dbs for ex",
+      "optional": "true"
+    },
+    {
+      "id": "myBootstrapAction",
+      "type": "String",
+      "helpLink": "https://docs.aws.amazon.com/console/datapipeline/emr_bootstrap_actions",
+      "helpText": "Bootstrap actions are scripts that are executed during setup before Hadoop starts on every cluster node.",
+      "description": "Bootstrap action(s)",
+      "isArray": "true",
+      "optional": "true"
+    },
+    {
+      "id": "myMasterInstanceType",
+      "type": "String",
+      "default": "m5.xlarge",
+      "helpText": "The Master instance assigns Hadoop tasks to core and task nodes, and monitors their status.",
+      "description": "Master node instance type"
+    }
+  ],
+  "values": {
+    "myEMRReleaseLabel": "emr-5.26.0",
+    "myMasterInstanceType": "m5.xlarge",
+    "myBootstrapAction": [
+      "s3://some_bucket/some_script.sh"
+    ],
+    "myEmrStep": [
+      "some_setup_command",
+      "some_spark_submit"
+    ],
+    "mySubnet":"some_value",
+    "myPipelineLogUri": "some_bucket",
+    "myEC2KeyPair": "some_key_pair",
+    "myScheduleType": "ONDEMAND",
+    "myPeriod": "1 Day",
+    "myStartDateTime": "2019-09-09T00:00:00"
+  }
+}

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -295,12 +295,14 @@ class DeployPySparkScriptOnAws(object):
                     'InstanceRole': 'MASTER',
                     'InstanceType': self.ec2_instance_master,
                     'InstanceCount': 1,
-                    }, {
-                    'Name': 'EmrCore',
-                    'InstanceRole': 'CORE',
-                    'InstanceType': self.ec2_instance_slaves,
-                    'InstanceCount': self.emr_core_instances,
-                    }],
+                    },
+                    # {
+                    # 'Name': 'EmrCore',
+                    # 'InstanceRole': 'CORE',
+                    # 'InstanceType': self.ec2_instance_slaves,
+                    # 'InstanceCount': self.emr_core_instances,
+                    # }
+                    ],
                 'Ec2KeyName': self.ec2_key_name,
                 'KeepJobFlowAliveWhenNoSteps': self.deploy_args.get('leave_on', False),
                 'Ec2SubnetId': self.ec2_subnet_id,

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -296,6 +296,7 @@ class DeployPySparkScriptOnAws(object):
                     'InstanceType': self.ec2_instance_master,
                     'InstanceCount': 1,
                     },
+                    ## TODO: re-enable below when there is a cleaner way to choose between 1 node and multi node clusters.
                     # {
                     # 'Name': 'EmrCore',
                     # 'InstanceRole': 'CORE',
@@ -451,7 +452,8 @@ class DeployPySparkScriptOnAws(object):
     def define_data_pipeline(self, client, pipe_id):
         import awscli.customizations.datapipeline.translator as trans
 
-        definition_file = eu.LOCAL_APP_FOLDER+'core/definition.json'  # see syntax in datapipeline-dg.pdf p285 # to add in there: /*"AdditionalMasterSecurityGroups": "#{}",  /* To add later to match EMR mode */
+        definition_file = eu.LOCAL_APP_FOLDER+'core/definition_standalone_cluster.json'  # see syntax in datapipeline-dg.pdf p285 # to add in there: /*"AdditionalMasterSecurityGroups": "#{}",  /* To add later to match EMR mode */
+        # TODO: change above to have type and number of instances chooseable from args, implying using "core/definition.json" for multi-node clusters.
         definition = json.load(open(definition_file, 'r')) # Note: Data Pipeline doesn't support emr-6.0.0 yet.
 
         pipelineObjects = trans.definition_to_api_objects(definition)

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -471,7 +471,7 @@ class ETL_Base(object):
                   now_dt=now_dt,
                   is_incremental=self.jargs.is_incremental,
                   incremental_type=self.jargs.merged_args.get('incremental_type', 'no_schema'),
-                  partitionby=self.jargs.output.get('inc_field'),
+                  partitionby=self.jargs.output.get('inc_field') or self.jargs.merged_args.get('partitionby'),
                   file_tag=self.jargs.merged_args.get('file_tag'))  # TODO: make param standard in cmd_args ?
 
     def save(self, output, path, base_path, type, now_dt=None, is_incremental=None, incremental_type=None, partitionby=None, file_tag=None):
@@ -488,7 +488,8 @@ class ETL_Base(object):
             path += 'inc_{}{}/'.format(current_time, file_tag)
 
         write_mode = 'append' if incremental_type == 'partitioned' else 'overwrite'
-        partitionby = partitionby.split(',') if partitionby and incremental_type == 'partitioned' else []
+        # partitionby = partitionby.split(',') if partitionby and incremental_type == 'partitioned' else []
+        partitionby = partitionby.split(',') if partitionby else []
 
         # TODO: deal with cases where "output" is df when expecting rdd, or at least raise issue in a cleaner way.
         if type == 'txt':

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -625,6 +625,7 @@ class Period_Builder():
         periods = self.get_first_to_last_day(first_day_input)
         if last_run_period:
             periods = [item for item in periods if item > last_run_period]
+        # periods = [item for item in periods if item < '2021-01-02']  # TODO: make end period parametrizable from args.
         return periods
 
 

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -408,6 +408,7 @@ class ETL_Base(object):
                 .option("url", url) \
                 .option("user", db['user']) \
                 .option("password", db['password']) \
+                .option("customSchema", self.jargs.merged_args.get('jdbc_custom_schema', '')) \
                 .option("query", query_str) \
                 .load()
         return sdf

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -247,7 +247,7 @@ class ETL_Base(object):
             app_args[item] = self.load_input(item)
             logger.info("Input '{}' loaded.".format(item))
 
-        if self.jargs.is_incremental:
+        if self.jargs.is_incremental and self.jargs.inputs[item]['type'] not in ('mysql', 'clickouse'):
             if self.jargs.merged_args.get('motm_incremental'):
                 app_args = self.filter_incremental_inputs_motm(app_args)
             else:

--- a/jobs/generic/dummy_job.py
+++ b/jobs/generic/dummy_job.py
@@ -1,0 +1,11 @@
+from core.etl_utils import ETL_Base, Commandliner
+from pyspark.sql.types import StructType
+
+class Job(ETL_Base):
+    def transform(self):
+        return self.sc_sql.createDataFrame([], StructType([]))
+
+
+if __name__ == "__main__":
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
+    Commandliner(Job, **args)


### PR DESCRIPTION
Force standalone clusters for now for both ad-hoc EMR and scheduled EMR (through AWS Data Pipeline).

Other:
 * added way to extract incremental data based on range instead of fix value filter
 * added arg to chose csv delimiter option (new param `csv_delimiter `).
 * added way to force specific schema when extracting from jdbc (new param `jdbc_custom_schema`)
 * added way to use spark partitioning scheme (instead of mine)
 * added dummy_job.py for jobs that do nothing and are just meant to run dependencies at once.