### PR TITLE
back to multi nodes by default

### DIFF
--- a/core/deploy.py
+++ b/core/deploy.py
@@ -296,13 +296,14 @@ class DeployPySparkScriptOnAws(object):
                     'InstanceType': self.ec2_instance_master,
                     'InstanceCount': 1,
                     },
-                    ## TODO: re-enable below when there is a cleaner way to choose between 1 node and multi node clusters.
-                    # {
-                    # 'Name': 'EmrCore',
-                    # 'InstanceRole': 'CORE',
-                    # 'InstanceType': self.ec2_instance_slaves,
-                    # 'InstanceCount': self.emr_core_instances,
-                    # }
+                    ## Commenting below allows running on single node cluster.
+                    ## TODO: check to have single node cluster by default when issue with pushing data to redshift with spark connector works.
+                    {
+                    'Name': 'EmrCore',
+                    'InstanceRole': 'CORE',
+                    'InstanceType': self.ec2_instance_slaves,
+                    'InstanceCount': self.emr_core_instances,
+                    }
                     ],
                 'Ec2KeyName': self.ec2_key_name,
                 'KeepJobFlowAliveWhenNoSteps': self.deploy_args.get('leave_on', False),
@@ -452,8 +453,9 @@ class DeployPySparkScriptOnAws(object):
     def define_data_pipeline(self, client, pipe_id):
         import awscli.customizations.datapipeline.translator as trans
 
+        ## Changing below to definition_standalone_cluster.json allows running on single node cluster.
+        ## TODO: check to have single node cluster by default when issue with pushing data to redshift with spark connector works.
         definition_file = eu.LOCAL_APP_FOLDER+'core/definition_standalone_cluster.json'  # see syntax in datapipeline-dg.pdf p285 # to add in there: /*"AdditionalMasterSecurityGroups": "#{}",  /* To add later to match EMR mode */
-        # TODO: change above to have type and number of instances chooseable from args, implying using "core/definition.json" for multi-node clusters.
         definition = json.load(open(definition_file, 'r')) # Note: Data Pipeline doesn't support emr-6.0.0 yet.
 
         pipelineObjects = trans.definition_to_api_objects(definition)


### PR DESCRIPTION
since single node cluster fails sending data to redshift with spark connector.

Error:
```
Traceback (most recent call last):
  File "/home/hadoop/app/scripts.zip/core/etl_utils.py", line 76, in etl
  File "/home/hadoop/app/scripts.zip/core/etl_utils.py", line 162, in etl_one_pass
  File "/home/hadoop/app/scripts.zip/core/etl_utils.py", line 547, in copy_to_redshift_using_spark
  File "/mnt/tmp/spark-243484dc-b57f-424b-8b5b-826830e22db9/userFiles-89aecb34-c475-41ff-8220-8349b3c99f07/scripts.zip/core/redshift_spark.py", line 25, in create_table
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/sql/readwriter.py", line 732, in save
  File "/usr/lib/spark/python/lib/py4j-0.10.7-src.zip/py4j/java_gateway.py", line 1257, in __call__
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/sql/utils.py", line 63, in deco
  File "/usr/lib/spark/python/lib/py4j-0.10.7-src.zip/py4j/protocol.py", line 328, in get_return_value
py4j.protocol.Py4JJavaError: An error occurred while calling o476.save.
: org.apache.spark.SparkException: Job aborted.
	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.write(FileFormatWriter.scala:198)
	at org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand.run(InsertIntoHadoopFsRelationCommand.scala:159)
	at org.apache.spark.sql.execution.command.DataWritingCommandExec.sideEffectResult$lzycompute(commands.scala:104)
	at org.apache.spark.sql.execution.command.DataWritingCommandExec.sideEffectResult(commands.scala:102)
	at org.apache.spark.sql.execution.command.DataWritingCommandExec.doExecute(commands.scala:122)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:131)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:127)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$executeQuery$1.apply(SparkPlan.scala:156)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:152)
	at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:127)
```