### PR TITLE
break if input folder has more than 999 sub folders

### DIFF
--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -914,8 +914,9 @@ class FS_Ops_Dispatcher():
         bucket_name = fname_parts[0]
         prefix = '/'.join(fname_parts[1:])
         client = boto3.client('s3')
-        objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')
+        objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
         paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
+        assert len(paths) <= 999
         return paths
 
     # --- dir_exist set of functions ----


### PR DESCRIPTION
Quick fix.
This is a problem when using `s3://some/path/{latest}/` in input path when `s3://some/path/` has more than 1000 sub folders. The code will list subfolders to pick the latest but will currently only list the first 1000 and therefore pick an older folder.
With this change it will break and users will have to delete previous versions of the datasets.