### PR TITLE
Listdir cluster pagination

### DIFF
--- a/core/definition.json
+++ b/core/definition.json
@@ -20,7 +20,7 @@
       "keyPair": "#{myEC2KeyPair}",
       "masterInstanceType": "#{myMasterInstanceType}",
       "releaseLabel": "#{myEMRReleaseLabel}",
-      "terminateAfter": "400 Minutes",
+      "terminateAfter": "#{myTerminateAfter}",
       "applications": "spark",
       "configuration": {"ref": "spark-env" }
     },
@@ -130,6 +130,13 @@
       "description": "EMR Release Label"
     },
     {
+      "id": "myTerminateAfter",
+      "type": "String",
+      "default": "180 Minutes",
+      "helpText": "Determines the timeout time.",
+      "description": "Time to timeout"
+    },
+    {
       "id": "myCoreInstanceCount",
       "type": "Integer",
       "default": "1",
@@ -166,6 +173,7 @@
   ],
   "values": {
     "myEMRReleaseLabel": "emr-5.26.0",
+    "myTerminateAfter": "180 Minutes",
     "myMasterInstanceType": "m5.xlarge",
     "myBootstrapAction": [
       "s3://some_bucket/some_script.sh"

--- a/core/deploy.py
+++ b/core/deploy.py
@@ -509,7 +509,6 @@ class DeployPySparkScriptOnAws(object):
             myStartDateTime = self.deploy_args['start_date'].format(today=datetime.today().strftime('%Y-%m-%d'))
         else :
             myStartDateTime = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
-        # TODO: self.app_args['start_date'] is taken from jobs_metadata_local.yml, instead of jobs_metadata.yml. Fix it
         bootstrap = 's3://{}/setup_nodes.sh'.format(self.package_path_with_bucket)
 
         for ii, item in enumerate(parameterValues):
@@ -527,6 +526,8 @@ class DeployPySparkScriptOnAws(object):
                 parameterValues[ii] = {'id': u'myStartDateTime', 'stringValue': myStartDateTime}
             elif 'myBootstrapAction' in item.values():
                 parameterValues[ii] = {'id': u'myBootstrapAction', 'stringValue': bootstrap}
+            elif 'myTerminateAfter' in item.values():
+                parameterValues[ii] = {'id': u'myTerminateAfter', 'stringValue': self.deploy_args.get('terminate_after', '180 Minutes')}
 
         # Change steps to include proper path
         setup_command =  's3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://{s3_tmp_path}/setup_master.sh,s3://{s3_tmp_path}'.format(s3_tmp_path=self.package_path_with_bucket) # s3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/setup_master.sh,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -919,6 +919,7 @@ class FS_Ops_Dispatcher():
         client = boto3.client('s3')
         objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
         paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
+        print('Number of folders in path "{}": {}'.format(path, len(paths)))
 
         # paginator = client.get_paginator('list_objects')
         # objects = paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter='/')

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -829,10 +829,15 @@ class Job_Args_Parser():
 
 
 class FS_Ops_Dispatcher():
-    # TODO: remove storage var not used anymore accross all functions below
+    # TODO: remove 'storage' var not used anymore accross all functions below, since now infered from path
+
+    @staticmethod
+    def is_s3_path(path):
+        return path.startswith('s3://') or path.startswith('s3a://')
+
     # --- save_metadata set of functions ----
     def save_metadata(self, fname, content, storage):
-        self.save_metadata_cluster(fname, content) if fname.startswith('s3://') or fname.startswith('s3a://') else self.save_metadata_local(fname, content)
+        self.save_metadata_cluster(fname, content) if self.is_s3_path(fname) else self.save_metadata_local(fname, content)
 
     @staticmethod
     def save_metadata_local(fname, content):
@@ -853,7 +858,7 @@ class FS_Ops_Dispatcher():
 
     # --- save_file set of functions ----
     def save_file(self, fname, content, storage):
-        self.save_file_cluster(fname, content) if fname.startswith('s3://') or fname.startswith('s3a://') else self.save_file_local(fname, content)
+        self.save_file_cluster(fname, content) if self.is_s3_path(fname) else self.save_file_local(fname, content)
 
     @staticmethod
     def save_file_local(fname, content):
@@ -877,7 +882,7 @@ class FS_Ops_Dispatcher():
 
     # --- load_file set of functions ----
     def load_file(self, fname, storage):
-        return self.load_file_cluster(fname) if fname.startswith('s3://') or fname.startswith('s3a://') else self.load_file_local(fname)
+        return self.load_file_cluster(fname) if self.is_s3_path(fname) else self.load_file_local(fname)
 
     @staticmethod
     def load_file_local(fname):
@@ -897,8 +902,7 @@ class FS_Ops_Dispatcher():
 
     # --- listdir set of functions ----
     def listdir(self, path, storage):
-        # return self.listdir_cluster(path) if storage=='s3' else self.listdir_local(path)
-        return self.listdir_cluster(path) if path.startswith('s3://') or path.startswith('s3a://') else self.listdir_local(path)
+        return self.listdir_cluster(path) if self.is_s3_path(path) else self.listdir_local(path)
 
     @staticmethod
     def listdir_local(path):
@@ -924,7 +928,7 @@ class FS_Ops_Dispatcher():
 
     # --- dir_exist set of functions ----
     def dir_exist(self, path, storage):
-        return self.dir_exist_cluster(path) if storage=='s3' else self.dir_exist_local(path)
+        return self.dir_exist_cluster(path) if self.is_s3_path(path) else self.dir_exist_local(path)
 
     @staticmethod
     def dir_exist_local(path):

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -917,20 +917,9 @@ class FS_Ops_Dispatcher():
         bucket_name = fname_parts[0]
         prefix = '/'.join(fname_parts[1:])
         client = boto3.client('s3')
-        # objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
-        # paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
         paginator = client.get_paginator('list_objects')
         objects = paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter='/')
-        # for prefix in objects.search('CommonPrefixes'):
-        #     if prefix == None:
-        # paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
         paths = [item['Prefix'].split('/')[-2] for item in objects.search('CommonPrefixes')]
-        # for object in objects.search('CommonPrefixes'):
-        #     import ipdb; ipdb.set_trace()
-
-        print('Number of folders in path "{}": {}'.format(path, len(paths)))
-
-        # assert len(paths) <= 999
         return paths
 
     # --- dir_exist set of functions ----

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -917,16 +917,20 @@ class FS_Ops_Dispatcher():
         bucket_name = fname_parts[0]
         prefix = '/'.join(fname_parts[1:])
         client = boto3.client('s3')
-        objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
-        paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
-        print('Number of folders in path "{}": {}'.format(path, len(paths)))
-
-        # paginator = client.get_paginator('list_objects')
-        # objects = paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter='/')
+        # objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
+        # paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
+        paginator = client.get_paginator('list_objects')
+        objects = paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter='/')
         # for prefix in objects.search('CommonPrefixes'):
         #     if prefix == None:
+        # paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
+        paths = [item['Prefix'].split('/')[-2] for item in objects.search('CommonPrefixes')]
+        # for object in objects.search('CommonPrefixes'):
+        #     import ipdb; ipdb.set_trace()
 
-        assert len(paths) <= 999
+        print('Number of folders in path "{}": {}'.format(path, len(paths)))
+
+        # assert len(paths) <= 999
         return paths
 
     # --- dir_exist set of functions ----

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -739,7 +739,8 @@ class Job_Yml_Parser():
 
 class Job_Args_Parser():
 
-    DEPLOY_ARGS_LIST = ['aws_config_file', 'aws_setup', 'leave_on', 'push_secrets', 'frequency', 'start_date', 'email', 'mode', 'deploy']
+    DEPLOY_ARGS_LIST = ['aws_config_file', 'aws_setup', 'leave_on', 'push_secrets', 'frequency', 'start_date',
+                        'email', 'mode', 'deploy', 'terminate_after']
 
     def __init__(self, defaults_args, yml_args, job_args, cmd_args, job_name=None, loaded_inputs={}):
         """Mix all params, add more and tweak them when needed (like depending on storage type, execution mode...).

--- a/core/etl_utils.py
+++ b/core/etl_utils.py
@@ -829,9 +829,10 @@ class Job_Args_Parser():
 
 
 class FS_Ops_Dispatcher():
+    # TODO: remove storage var not used anymore accross all functions below
     # --- save_metadata set of functions ----
     def save_metadata(self, fname, content, storage):
-        self.save_metadata_cluster(fname, content) if storage=='s3' else self.save_metadata_local(fname, content)
+        self.save_metadata_cluster(fname, content) if fname.startswith('s3://') or fname.startswith('s3a://') else self.save_metadata_local(fname, content)
 
     @staticmethod
     def save_metadata_local(fname, content):
@@ -852,7 +853,7 @@ class FS_Ops_Dispatcher():
 
     # --- save_file set of functions ----
     def save_file(self, fname, content, storage):
-        self.save_file_cluster(fname, content) if storage=='s3' else self.save_file_local(fname, content)
+        self.save_file_cluster(fname, content) if fname.startswith('s3://') or fname.startswith('s3a://') else self.save_file_local(fname, content)
 
     @staticmethod
     def save_file_local(fname, content):
@@ -876,7 +877,7 @@ class FS_Ops_Dispatcher():
 
     # --- load_file set of functions ----
     def load_file(self, fname, storage):
-        return self.load_file_cluster(fname) if storage=='s3' else self.load_file_local(fname)
+        return self.load_file_cluster(fname) if fname.startswith('s3://') or fname.startswith('s3a://') else self.load_file_local(fname)
 
     @staticmethod
     def load_file_local(fname):
@@ -896,7 +897,8 @@ class FS_Ops_Dispatcher():
 
     # --- listdir set of functions ----
     def listdir(self, path, storage):
-        return self.listdir_cluster(path) if storage=='s3' else self.listdir_local(path)
+        # return self.listdir_cluster(path) if storage=='s3' else self.listdir_local(path)
+        return self.listdir_cluster(path) if path.startswith('s3://') or path.startswith('s3a://') else self.listdir_local(path)
 
     @staticmethod
     def listdir_local(path):
@@ -917,6 +919,12 @@ class FS_Ops_Dispatcher():
         client = boto3.client('s3')
         objects = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter='/')  # TODO deal with pagination since it lists only 1000 elements here, or add a check that list is < 1000 items.
         paths = [item['Prefix'].split('/')[-2] for item in objects.get('CommonPrefixes')]
+
+        # paginator = client.get_paginator('list_objects')
+        # objects = paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter='/')
+        # for prefix in objects.search('CommonPrefixes'):
+        #     if prefix == None:
+
         assert len(paths) <= 999
         return paths
 


### PR DESCRIPTION
Bug fix: Added pagination in Listdir_cluster to deal with case when path has more than 1000 folders. It was previously ignoring  latest folders and therefore picking an old one as the latest one.

Other:
 * infer storage type (s3 or local) from path instead of input variable. Allows working with data from S3 in local runs, especially when using '{latest}'
 * made AWS EMR timeout selectable for each job. 

cc @annafonte